### PR TITLE
Fix Gemini credential key mismatch in OAuth flow

### DIFF
--- a/nadirclaw/cli.py
+++ b/nadirclaw/cli.py
@@ -602,7 +602,7 @@ def gemini_login(timeout):
     if access_token:
         from nadirclaw.credentials import save_oauth_credential
         expires_in = max(int(expires_at - _time.time()), 3600) if expires_at else 3600
-        save_oauth_credential("gemini", access_token, refresh_token, expires_in, metadata={
+        save_oauth_credential("google", access_token, refresh_token, expires_in, metadata={
             "project_id": project_id,
             "email": email,
         })
@@ -628,7 +628,7 @@ def gemini_logout():
     """Remove stored Gemini OAuth credential."""
     from nadirclaw.credentials import remove_credential
 
-    if remove_credential("gemini"):
+    if remove_credential("google"):
         click.echo("Gemini credential removed.")
     else:
         click.echo("No Gemini credential found.")

--- a/nadirclaw/credentials.py
+++ b/nadirclaw/credentials.py
@@ -273,6 +273,24 @@ def get_credential(provider: str) -> Optional[str]:
     return None
 
 
+def get_credential_entry(provider: str) -> Optional[dict]:
+    """Return the full credential entry dict for a provider, or None.
+
+    Unlike get_credential() which returns only the token string, this
+    returns the full dict including source, refresh_token, expires_at, etc.
+    Useful for distinguishing OAuth credentials from API keys.
+    """
+    creds = _read_credentials()
+    entry = creds.get(provider)
+    if entry and entry.get("token"):
+        # Ensure token is refreshed if needed
+        _maybe_refresh_oauth(provider, entry)
+        # Re-read in case refresh updated it
+        creds = _read_credentials()
+        return creds.get(provider)
+    return None
+
+
 def get_credential_source(provider: str) -> Optional[str]:
     """Return the source label for how a credential was resolved.
 


### PR DESCRIPTION
## Summary
- `gemini_login` and `gemini_logout` in `cli.py` saved/removed credentials under the `"gemini"` key, but `detect_provider()` resolves Gemini models to `"google"`, so `get_credential("google")` always returned `None`
- This caused all Gemini API calls to fail with "No Google/Gemini API key configured" even though the credential was stored
- Also adds `get_credential_entry()` helper to `credentials.py` for distinguishing OAuth vs API key credentials (useful for future Vertex AI support)

## Test plan
- [ ] Run `nadirclaw auth gemini login`, verify credential is stored under `"google"` key in `credentials.json`
- [ ] Run `nadirclaw auth gemini logout`, verify it removes the `"google"` key
- [ ] Run `nadirclaw auth status`, verify Gemini credential still shows correctly
- [ ] Start server with `nadirclaw serve`, send a request, verify Gemini models respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)