### PR TITLE
setup: prompt OLLAMA_API_BASE before credentials and use it for Ollama connectivity/model fetch

### DIFF
--- a/nadirclaw/setup.py
+++ b/nadirclaw/setup.py
@@ -787,8 +787,7 @@ def write_env_file(
         lines.append("")
 
     if ollama_api_base:
-        if not api_keys:
-            lines.append("# API Keys")
+        lines.append("# Ollama")
         lines.append(f"OLLAMA_API_BASE={_normalize_ollama_api_base(ollama_api_base)}")
         lines.append("")
 


### PR DESCRIPTION
### PR Description (Changes)

- Prompt `OLLAMA_API_BASE` immediately after provider selection when `ollama` is selected.
- Normalize Ollama base URL with `_normalize_ollama_api_base()`:
  - blank input falls back to `http://localhost:11434`
  - auto-adds `http://` when scheme is missing
  - trims trailing `/`.
- Use selected `OLLAMA_API_BASE` for Ollama connectivity checks in credentials step.
- Use selected `OLLAMA_API_BASE` to fetch Ollama models in “Fetching Available Models”.
- Keep model-selection flow unchanged, but now free-model list reflects models from the user-provided Ollama host.
- Persist `OLLAMA_API_BASE` to `~/.nadirclaw/.env` in `write_env_file()`.
- Added/used base-aware connectivity helper (`_check_ollama_connectivity_with_base`).
- Updated setup wizard orchestration in `run_setup_wizard()` to pass Ollama base through credential + fetch steps.

### User-visible behavior

- For Ollama setups, hostname/base is requested **before**:
  1. Credentials connectivity check  
  2. Available model fetching  
  3. Model selection  

This ensures fetched Ollama models come from the intended endpoint.