### PR TITLE
fix: complete Ollama setup flow with runtime api_base support

### DIFF
--- a/nadirclaw/server.py
+++ b/nadirclaw/server.py
@@ -659,6 +659,10 @@ async def _call_litellm(
         if api_key:
             call_kwargs["api_key"] = api_key
 
+    # Pass api_base for Ollama models so LiteLLM reaches the right host
+    if litellm_model.startswith("ollama/") or litellm_model.startswith("ollama_chat/"):
+        call_kwargs["api_base"] = settings.OLLAMA_API_BASE
+
     logger.debug("Calling LiteLLM: model=%s (provider=%s)", litellm_model, provider)
     try:
         response = await litellm.acompletion(**call_kwargs)

--- a/nadirclaw/setup.py
+++ b/nadirclaw/setup.py
@@ -67,6 +67,8 @@ PROVIDER_INFO: Dict[str, Dict] = {
 
 PROVIDER_ORDER = ["openai", "anthropic", "google", "deepseek", "ollama"]
 
+OLLAMA_DEFAULT_API_BASE = "http://localhost:11434"
+
 # Tier defaults — ordered preference per provider
 _TIER_DEFAULTS = {
     "simple": {
@@ -102,6 +104,31 @@ ENV_FILE = CONFIG_DIR / ".env"
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _normalize_ollama_api_base(raw: str) -> str:
+    """Normalize an Ollama API base URL.
+
+    Strips whitespace, defaults to localhost:11434, prepends http:// if no
+    scheme is present, and strips any trailing slash.
+    """
+    raw = raw.strip()
+    if not raw:
+        return OLLAMA_DEFAULT_API_BASE
+    if not raw.startswith("http://") and not raw.startswith("https://"):
+        raw = "http://" + raw
+    return raw.rstrip("/")
+
+
+def _check_ollama_connectivity_with_base(api_base: str) -> bool:
+    """Check if Ollama is reachable at the given base URL."""
+    api_base = _normalize_ollama_api_base(api_base)
+    try:
+        req = urllib.request.Request(f"{api_base}/api/tags")
+        with urllib.request.urlopen(req, timeout=3):
+            return True
+    except Exception:
+        return False
+
 
 def is_first_run() -> bool:
     """Check if NadirClaw has been configured (i.e. .env exists)."""
@@ -243,9 +270,10 @@ def _fetch_deepseek_models(credential: str) -> List[str]:
     return sorted(models)
 
 
-def _fetch_ollama_models() -> List[str]:
+def _fetch_ollama_models(api_base: Optional[str] = None) -> List[str]:
     """Fetch locally installed models from Ollama."""
-    req = urllib.request.Request("http://localhost:11434/api/tags")
+    base = _normalize_ollama_api_base(api_base or "")
+    req = urllib.request.Request(f"{base}/api/tags")
     try:
         with urllib.request.urlopen(req, timeout=3) as resp:
             data = json.loads(resp.read())
@@ -320,7 +348,9 @@ def _filter_google_top(models: List[str]) -> List[str]:
     return sorted(top)
 
 
-def fetch_provider_models(provider: str, credential: str) -> List[str]:
+def fetch_provider_models(
+    provider: str, credential: str, ollama_api_base: Optional[str] = None,
+) -> List[str]:
     """Fetch available model IDs from a provider's API.
 
     Returns only top current-generation models, or empty list on failure.
@@ -332,7 +362,7 @@ def fetch_provider_models(provider: str, credential: str) -> List[str]:
         "deepseek": _fetch_deepseek_models,
     }
     if provider == "ollama":
-        return _fetch_ollama_models()
+        return _fetch_ollama_models(api_base=ollama_api_base)
     fetcher = fetchers.get(provider)
     if fetcher and credential:
         raw = fetcher(credential)
@@ -435,15 +465,12 @@ def prompt_provider_selection(existing: Optional[List[str]] = None) -> List[str]
 
 def _check_ollama_connectivity() -> bool:
     """Check if Ollama is running at localhost:11434."""
-    try:
-        req = urllib.request.Request("http://localhost:11434/api/tags")
-        with urllib.request.urlopen(req, timeout=3):
-            return True
-    except Exception:
-        return False
+    return _check_ollama_connectivity_with_base(OLLAMA_DEFAULT_API_BASE)
 
 
-def prompt_credential_for_provider(provider: str, reconfigure: bool = False) -> Optional[str]:
+def prompt_credential_for_provider(
+    provider: str, reconfigure: bool = False, ollama_api_base: Optional[str] = None,
+) -> Optional[str]:
     """Prompt user for credentials for a single provider.
 
     Returns the credential string, or None if skipped.
@@ -454,11 +481,12 @@ def prompt_credential_for_provider(provider: str, reconfigure: bool = False) -> 
 
     # Ollama needs no key
     if provider == "ollama":
+        base = _normalize_ollama_api_base(ollama_api_base or "")
         click.echo(f"  {info['display']}: Checking connectivity...")
-        if _check_ollama_connectivity():
-            click.echo("    Ollama is running at localhost:11434")
+        if _check_ollama_connectivity_with_base(base):
+            click.echo(f"    Ollama is running at {base}")
         else:
-            click.echo("    Ollama not detected at localhost:11434")
+            click.echo(f"    Ollama not detected at {base}")
             click.echo("    Make sure Ollama is running before using local models.")
         click.echo()
         return "local"
@@ -728,6 +756,7 @@ def write_env_file(
     reasoning: Optional[str] = None,
     free: Optional[str] = None,
     api_keys: Optional[Dict[str, str]] = None,
+    ollama_api_base: Optional[str] = None,
 ) -> Path:
     """Write ~/.nadirclaw/.env with model configuration.
 
@@ -767,6 +796,12 @@ def write_env_file(
     if free:
         lines.append(f"NADIRCLAW_FREE_MODEL={free}")
     lines.append("")
+
+    # Ollama
+    if ollama_api_base:
+        lines.append("# Ollama")
+        lines.append(f"OLLAMA_API_BASE={ollama_api_base}")
+        lines.append("")
 
     # Server defaults
     lines.append("# Server")
@@ -828,6 +863,20 @@ def run_setup_wizard(reconfigure: bool = False):
     # Step 2: Provider selection
     providers = prompt_provider_selection(existing=existing_creds or None)
 
+    # Step 2.5: Ollama API base (if Ollama selected)
+    ollama_api_base: Optional[str] = None
+    if "ollama" in providers:
+        click.echo("-" * 56)
+        click.echo("  Ollama Configuration")
+        click.echo("-" * 56)
+        click.echo()
+        raw_base = click.prompt(
+            "  Ollama API base URL",
+            default=OLLAMA_DEFAULT_API_BASE,
+        )
+        ollama_api_base = _normalize_ollama_api_base(raw_base)
+        click.echo(f"  Using: {ollama_api_base}\n")
+
     # Step 3: Credential collection
     click.echo("-" * 56)
     click.echo("  Credentials")
@@ -837,7 +886,9 @@ def run_setup_wizard(reconfigure: bool = False):
     api_keys: Dict[str, str] = {}
     collected_credentials: Dict[str, str] = {}
     for provider in providers:
-        cred = prompt_credential_for_provider(provider, reconfigure=reconfigure)
+        cred = prompt_credential_for_provider(
+            provider, reconfigure=reconfigure, ollama_api_base=ollama_api_base,
+        )
         if cred:
             collected_credentials[provider] = cred
             # Collect API keys for .env (only plain keys, not OAuth tokens)
@@ -859,7 +910,7 @@ def run_setup_wizard(reconfigure: bool = False):
         cred = collected_credentials.get(provider)
         display = PROVIDER_INFO[provider]["display"]
         click.echo(f"  {display}...", nl=False)
-        models = fetch_provider_models(provider, cred or "")
+        models = fetch_provider_models(provider, cred or "", ollama_api_base=ollama_api_base)
         if models:
             fetched_models[provider] = models
             click.echo(f" {len(models)} models found")
@@ -909,6 +960,7 @@ def run_setup_wizard(reconfigure: bool = False):
         reasoning=reasoning_model,
         free=free_model,
         api_keys=api_keys,
+        ollama_api_base=ollama_api_base,
     )
     click.echo(f"  Wrote {env_path}")
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -11,10 +11,13 @@ from click.testing import CliRunner
 
 from nadirclaw.setup import (
     ENV_FILE,
+    OLLAMA_DEFAULT_API_BASE,
+    _check_ollama_connectivity_with_base,
     _filter_anthropic_top,
     _filter_google_top,
     _filter_openai_top,
     _filter_top_models,
+    _normalize_ollama_api_base,
     classify_model_tier,
     detect_existing_config,
     fetch_provider_models,
@@ -506,3 +509,112 @@ class TestSetupCLI:
         runner = CliRunner()
         result = runner.invoke(main, ["setup"], input="n\n")
         assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# _normalize_ollama_api_base
+# ---------------------------------------------------------------------------
+
+class TestNormalizeOllamaApiBase:
+    def test_empty_returns_default(self):
+        assert _normalize_ollama_api_base("") == OLLAMA_DEFAULT_API_BASE
+
+    def test_blank_returns_default(self):
+        assert _normalize_ollama_api_base("   ") == OLLAMA_DEFAULT_API_BASE
+
+    def test_already_normalized(self):
+        assert _normalize_ollama_api_base("http://localhost:11434") == "http://localhost:11434"
+
+    def test_missing_scheme(self):
+        assert _normalize_ollama_api_base("localhost:11434") == "http://localhost:11434"
+
+    def test_trailing_slash(self):
+        assert _normalize_ollama_api_base("http://localhost:11434/") == "http://localhost:11434"
+
+    def test_https_preserved(self):
+        assert _normalize_ollama_api_base("https://ollama.example.com") == "https://ollama.example.com"
+
+    def test_custom_host(self):
+        assert _normalize_ollama_api_base("http://192.168.1.50:11434") == "http://192.168.1.50:11434"
+
+
+# ---------------------------------------------------------------------------
+# _check_ollama_connectivity_with_base
+# ---------------------------------------------------------------------------
+
+class TestCheckOllamaConnectivityWithBase:
+    def test_reachable(self, monkeypatch):
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: mock_resp)
+        assert _check_ollama_connectivity_with_base("http://localhost:11434") is True
+
+    def test_unreachable(self, monkeypatch):
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            lambda *a, **k: (_ for _ in ()).throw(Exception("connection refused")),
+        )
+        assert _check_ollama_connectivity_with_base("http://localhost:11434") is False
+
+    def test_normalizes_url(self, monkeypatch):
+        """Should normalize the URL before connecting."""
+        captured = {}
+
+        def fake_urlopen(req, **kw):
+            captured["url"] = req.full_url
+            mock_resp = MagicMock()
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+        _check_ollama_connectivity_with_base("localhost:11434/")
+        assert captured["url"] == "http://localhost:11434/api/tags"
+
+
+# ---------------------------------------------------------------------------
+# fetch_provider_models with custom ollama_api_base
+# ---------------------------------------------------------------------------
+
+class TestFetchProviderModelsOllamaBase:
+    def test_ollama_custom_base(self, monkeypatch):
+        """Should use the custom api_base when fetching Ollama models."""
+        captured = {}
+
+        def fake_urlopen(req, **kw):
+            captured["url"] = req.full_url
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps({
+                "models": [{"name": "llama3.1:8b"}]
+            }).encode()
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            return mock_resp
+
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+        models = fetch_provider_models("ollama", "", ollama_api_base="http://192.168.1.50:11434")
+        assert "ollama/llama3.1:8b" in models
+        assert captured["url"] == "http://192.168.1.50:11434/api/tags"
+
+
+# ---------------------------------------------------------------------------
+# write_env_file with ollama_api_base
+# ---------------------------------------------------------------------------
+
+class TestWriteEnvFileOllama:
+    def test_includes_ollama_api_base(self, tmp_nadirclaw_dir):
+        _, fake_env = tmp_nadirclaw_dir
+        write_env_file(
+            simple="flash",
+            complex_model="gpt-4.1",
+            ollama_api_base="http://192.168.1.50:11434",
+        )
+        content = fake_env.read_text()
+        assert "OLLAMA_API_BASE=http://192.168.1.50:11434" in content
+
+    def test_omits_ollama_api_base_when_none(self, tmp_nadirclaw_dir):
+        _, fake_env = tmp_nadirclaw_dir
+        write_env_file(simple="flash", complex_model="gpt-4.1")
+        content = fake_env.read_text()
+        assert "OLLAMA_API_BASE" not in content


### PR DESCRIPTION
## Summary

Fixes the Ollama setup wizard to prompt for `OLLAMA_API_BASE` early in the flow, persist it to `.env`, and -- critically -- actually use it at request time when calling LiteLLM.

Closes #3. Supersedes #4.

## What changed

**`nadirclaw/setup.py`:**
- Added `OLLAMA_DEFAULT_API_BASE` constant
- Added `_normalize_ollama_api_base()` helper (strips whitespace, defaults to localhost, prepends http:// if missing, strips trailing slash)
- Added `_check_ollama_connectivity_with_base()` for checking arbitrary Ollama endpoints
- `_fetch_ollama_models()` and `fetch_provider_models()` now accept an optional `ollama_api_base` param
- `prompt_credential_for_provider()` uses the configured base for connectivity checks
- `write_env_file()` writes `OLLAMA_API_BASE` to `.env`
- `run_setup_wizard()` prompts for `OLLAMA_API_BASE` right after provider selection (before credentials)

**`nadirclaw/server.py`** (the missing piece from #4):
- In `_call_litellm`, if the model starts with `ollama/` or `ollama_chat/`, set `call_kwargs["api_base"] = settings.OLLAMA_API_BASE`. Without this, the setting was saved but never consumed at request time.

**`tests/test_setup.py`:**
- Tests for `_normalize_ollama_api_base` (empty, blank, already normalized, missing scheme, trailing slash, https preserved, custom host)
- Tests for `_check_ollama_connectivity_with_base` (reachable, unreachable, normalizes URL)
- Test for `fetch_provider_models` with custom `ollama_api_base`
- Tests for `write_env_file` with `ollama_api_base`

All 61 setup tests pass.