### PR TITLE
feat: upgrade-only session cache for agent frameworks

### DIFF
--- a/nadirclaw/routing.py
+++ b/nadirclaw/routing.py
@@ -329,9 +329,16 @@ class SessionCache:
 
     Keyed by a hash of the system prompt + first user message.
     TTL-based expiry with LRU eviction to cap memory usage.
+
+    Upgrade-only policy: cached tier can only escalate (simple→mid→complex→
+    reasoning), never downgrade.  This prevents a complex session from being
+    pinned to "simple" while still avoiding jarring model switches downward.
     """
 
-    def __init__(self, ttl_seconds: int = 1800, max_size: int = 10_000):
+    # Tier ordering — higher index = more capable model.
+    TIER_ORDER = {"simple": 0, "mid": 1, "complex": 2, "reasoning": 3}
+
+    def __init__(self, ttl_seconds: int = 300, max_size: int = 10_000):
         # OrderedDict gives O(1) move-to-end (move_to_end) and O(1) popitem(last=False)
         # for LRU eviction — replaces the old List-based access_order which was O(n).
         self._cache: OrderedDict[str, Tuple[str, str, float]] = OrderedDict()  # key → (model, tier, timestamp)
@@ -372,7 +379,12 @@ class SessionCache:
             self._cache.popitem(last=False)
 
     def get(self, messages: List[Any]) -> Optional[Tuple[str, str]]:
-        """Return (model, tier) if a session exists and isn't expired."""
+        """Return (model, tier) if a session exists and isn't expired.
+
+        The caller is expected to *always* run the classifier after this.
+        If the new classification yields a higher tier, call
+        ``upgrade_if_higher`` to atomically escalate the cached entry.
+        """
         key = self._make_key(messages)
         with self._lock:
             entry = self._cache.get(key)
@@ -385,15 +397,53 @@ class SessionCache:
             self._touch(key)
             return model, tier
 
-    def put(self, messages: List[Any], model: str, tier: str) -> None:
-        """Store a routing decision for this session."""
+    def upgrade_if_higher(
+        self, messages: List[Any], new_model: str, new_tier: str
+    ) -> Tuple[str, str]:
+        """Upgrade the cached tier if *new_tier* outranks the stored one.
+
+        Returns the (model, tier) that should actually be used — either the
+        newly upgraded values or the previously cached ones.
+        """
         key = self._make_key(messages)
+        new_rank = self.TIER_ORDER.get(new_tier, 0)
+        with self._lock:
+            entry = self._cache.get(key)
+            if entry is None:
+                # Nothing cached yet — store and return the new values.
+                self._cache[key] = (new_model, new_tier, time.time())
+                return new_model, new_tier
+            cached_model, cached_tier, _ts = entry
+            cached_rank = self.TIER_ORDER.get(cached_tier, 0)
+            if new_rank > cached_rank:
+                # Escalate — upgrade the cache entry.
+                self._cache[key] = (new_model, new_tier, time.time())
+                self._touch(key)
+                return new_model, new_tier
+            # Keep the existing (equal or higher) tier.
+            self._touch(key)
+            return cached_model, cached_tier
+
+    def put(self, messages: List[Any], model: str, tier: str) -> None:
+        """Store a routing decision for this session (upgrade-only).
+
+        If an entry already exists with a higher tier, this is a no-op.
+        """
+        key = self._make_key(messages)
+        new_rank = self.TIER_ORDER.get(tier, 0)
         with self._lock:
             # Periodic cleanup of expired entries
             self._cleanup_counter += 1
             if self._cleanup_counter >= self._cleanup_interval:
                 self._cleanup_counter = 0
                 self.clear_expired()
+
+            # Upgrade-only: don't downgrade an existing entry.
+            existing = self._cache.get(key)
+            if existing is not None:
+                _, cached_tier, _ = existing
+                if self.TIER_ORDER.get(cached_tier, 0) >= new_rank:
+                    return  # existing tier is equal or higher — skip
 
             self._cache[key] = (model, tier, time.time())
             self._touch(key)
@@ -415,7 +465,7 @@ class SessionCache:
 
 
 # Global session cache
-_session_cache = SessionCache(ttl_seconds=1800)
+_session_cache = SessionCache(ttl_seconds=300)
 
 
 def get_session_cache() -> SessionCache:

--- a/nadirclaw/routing.py
+++ b/nadirclaw/routing.py
@@ -399,30 +399,41 @@ class SessionCache:
 
     def upgrade_if_higher(
         self, messages: List[Any], new_model: str, new_tier: str
-    ) -> Tuple[str, str]:
+    ) -> Tuple[str, str, str]:
         """Upgrade the cached tier if *new_tier* outranks the stored one.
 
-        Returns the (model, tier) that should actually be used — either the
-        newly upgraded values or the previously cached ones.
+        Returns ``(model, tier, status)`` where status is one of:
+
+        - ``"new"``      — no entry existed (or was expired); fresh values stored
+        - ``"upgraded"`` — cached tier was lower; entry replaced with higher tier
+        - ``"kept"``     — cached tier was equal or higher; cached values returned
+
+        Expired entries are treated as missing so a stale high-tier entry
+        cannot block a fresh classification.
         """
         key = self._make_key(messages)
         new_rank = self.TIER_ORDER.get(new_tier, 0)
+        now = time.time()
         with self._lock:
             entry = self._cache.get(key)
+            # Treat expired entries as missing — fresh classification wins.
+            if entry is not None and now - entry[2] > self._ttl:
+                del self._cache[key]
+                entry = None
             if entry is None:
-                # Nothing cached yet — store and return the new values.
-                self._cache[key] = (new_model, new_tier, time.time())
-                return new_model, new_tier
+                self._cache[key] = (new_model, new_tier, now)
+                self._evict_lru()
+                return new_model, new_tier, "new"
             cached_model, cached_tier, _ts = entry
             cached_rank = self.TIER_ORDER.get(cached_tier, 0)
             if new_rank > cached_rank:
                 # Escalate — upgrade the cache entry.
-                self._cache[key] = (new_model, new_tier, time.time())
+                self._cache[key] = (new_model, new_tier, now)
                 self._touch(key)
-                return new_model, new_tier
+                return new_model, new_tier, "upgraded"
             # Keep the existing (equal or higher) tier.
             self._touch(key)
-            return cached_model, cached_tier
+            return cached_model, cached_tier, "kept"
 
     def put(self, messages: List[Any], model: str, tier: str) -> None:
         """Store a routing decision for this session (upgrade-only).

--- a/nadirclaw/server.py
+++ b/nadirclaw/server.py
@@ -1031,42 +1031,35 @@ async def chat_completions(
                 }
         else:
             # --- Smart routing (auto or no model specified) ---
-            # Check session cache first
+            # Always classify the current message, then apply
+            # upgrade-only session caching (never downgrade mid-session).
             session_cache = get_session_cache()
-            cached = session_cache.get(request.messages)
-            if cached:
-                cached_model, cached_tier = cached
-                selected_model = cached_model
-                analysis_info = {
-                    "strategy": "session-cache",
-                    "selected_model": selected_model,
-                    "tier": cached_tier,
-                    "confidence": 1.0,
-                    "complexity_score": 0,
-                }
-                logger.debug("Session cache hit: model=%s tier=%s", cached_model, cached_tier)
-            else:
-                selected_model, analysis_info = await _smart_route_full(
-                    request.messages, current_user
-                )
 
-                # Apply routing modifiers (agentic, reasoning, context window)
-                selected_model, final_tier, routing_info = apply_routing_modifiers(
-                    base_model=selected_model,
-                    base_tier=analysis_info.get("tier", "simple"),
-                    request_meta=req_meta,
-                    messages=request.messages,
-                    simple_model=settings.SIMPLE_MODEL,
-                    complex_model=settings.COMPLEX_MODEL,
-                    reasoning_model=settings.REASONING_MODEL,
-                    free_model=settings.FREE_MODEL,
-                )
-                analysis_info["tier"] = final_tier
-                analysis_info["selected_model"] = selected_model
-                analysis_info["routing_modifiers"] = routing_info
+            selected_model, analysis_info = await _smart_route_full(
+                request.messages, current_user
+            )
 
-                # Cache this decision for session persistence
-                session_cache.put(request.messages, selected_model, final_tier)
+            # Apply routing modifiers (agentic, reasoning, context window)
+            selected_model, final_tier, routing_info = apply_routing_modifiers(
+                base_model=selected_model,
+                base_tier=analysis_info.get("tier", "simple"),
+                request_meta=req_meta,
+                messages=request.messages,
+                simple_model=settings.SIMPLE_MODEL,
+                complex_model=settings.COMPLEX_MODEL,
+                reasoning_model=settings.REASONING_MODEL,
+                free_model=settings.FREE_MODEL,
+            )
+
+            # Upgrade-only cache: escalate if new tier is higher,
+            # keep cached tier if it's already equal or above.
+            selected_model, final_tier = session_cache.upgrade_if_higher(
+                request.messages, selected_model, final_tier
+            )
+
+            analysis_info["tier"] = final_tier
+            analysis_info["selected_model"] = selected_model
+            analysis_info["routing_modifiers"] = routing_info
 
         # Resolve provider credential
         from nadirclaw.credentials import detect_provider, get_credential

--- a/nadirclaw/server.py
+++ b/nadirclaw/server.py
@@ -1053,13 +1053,18 @@ async def chat_completions(
 
             # Upgrade-only cache: escalate if new tier is higher,
             # keep cached tier if it's already equal or above.
-            selected_model, final_tier = session_cache.upgrade_if_higher(
+            selected_model, final_tier, cache_status = session_cache.upgrade_if_higher(
                 request.messages, selected_model, final_tier
             )
 
             analysis_info["tier"] = final_tier
             analysis_info["selected_model"] = selected_model
             analysis_info["routing_modifiers"] = routing_info
+            analysis_info["cache_status"] = cache_status
+            if cache_status == "kept":
+                analysis_info["strategy"] = (
+                    analysis_info.get("strategy", "smart-routing") + "+session-cache"
+                )
 
         # Resolve provider credential
         from nadirclaw.credentials import detect_provider, get_credential

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -307,6 +307,132 @@ class TestSessionCache:
         removed = cache.clear_expired()
         assert removed == 1
 
+    # ----- put() upgrade-only guard ----------------------------------------
+
+    def test_put_does_not_downgrade(self):
+        """put() must not replace a higher-tier entry with a lower-tier one."""
+        cache = SessionCache(ttl_seconds=60)
+        msgs = [_msg("user", "Hello")]
+        cache.put(msgs, "claude-opus", "reasoning")
+        cache.put(msgs, "gpt-4o-mini", "simple")
+        # Reasoning outranks simple — original entry must remain.
+        assert cache.get(msgs) == ("claude-opus", "reasoning")
+
+    def test_put_keeps_equal_tier(self):
+        """put() with the same tier is a no-op (no timestamp churn either)."""
+        cache = SessionCache(ttl_seconds=60)
+        msgs = [_msg("user", "Hello")]
+        cache.put(msgs, "gpt-4o", "complex")
+        cache.put(msgs, "claude-sonnet", "complex")  # equal tier, different model
+        # Original model retained.
+        assert cache.get(msgs) == ("gpt-4o", "complex")
+
+    def test_put_upgrades_when_higher(self):
+        """put() with a higher tier replaces the cached entry."""
+        cache = SessionCache(ttl_seconds=60)
+        msgs = [_msg("user", "Hello")]
+        cache.put(msgs, "gpt-4o-mini", "simple")
+        cache.put(msgs, "claude-opus", "reasoning")
+        assert cache.get(msgs) == ("claude-opus", "reasoning")
+
+    # ----- upgrade_if_higher() ---------------------------------------------
+
+    def test_upgrade_if_higher_new_session(self):
+        """No cached entry → store the new values, status='new'."""
+        cache = SessionCache(ttl_seconds=60)
+        msgs = [_msg("user", "Hello")]
+        model, tier, status = cache.upgrade_if_higher(msgs, "gpt-4o", "complex")
+        assert (model, tier, status) == ("gpt-4o", "complex", "new")
+        assert cache.get(msgs) == ("gpt-4o", "complex")
+
+    def test_upgrade_if_higher_escalates(self):
+        """Lower cached tier → upgrade to higher tier, status='upgraded'."""
+        cache = SessionCache(ttl_seconds=60)
+        msgs = [_msg("user", "Hello")]
+        cache.upgrade_if_higher(msgs, "gpt-4o-mini", "simple")
+        model, tier, status = cache.upgrade_if_higher(
+            msgs, "claude-opus", "reasoning"
+        )
+        assert (model, tier, status) == ("claude-opus", "reasoning", "upgraded")
+        assert cache.get(msgs) == ("claude-opus", "reasoning")
+
+    def test_upgrade_if_higher_keeps_higher(self):
+        """Higher cached tier → keep cached values, status='kept'."""
+        cache = SessionCache(ttl_seconds=60)
+        msgs = [_msg("user", "Hello")]
+        cache.upgrade_if_higher(msgs, "claude-opus", "reasoning")
+        model, tier, status = cache.upgrade_if_higher(msgs, "gpt-4o-mini", "simple")
+        assert (model, tier, status) == ("claude-opus", "reasoning", "kept")
+        assert cache.get(msgs) == ("claude-opus", "reasoning")
+
+    def test_upgrade_if_higher_keeps_equal(self):
+        """Equal cached tier → keep cached values, status='kept'."""
+        cache = SessionCache(ttl_seconds=60)
+        msgs = [_msg("user", "Hello")]
+        cache.upgrade_if_higher(msgs, "gpt-4o", "complex")
+        model, tier, status = cache.upgrade_if_higher(msgs, "claude-sonnet", "complex")
+        assert (model, tier, status) == ("gpt-4o", "complex", "kept")
+
+    def test_upgrade_if_higher_full_hierarchy(self):
+        """simple < mid < complex < reasoning ordering is honored."""
+        cache = SessionCache(ttl_seconds=60)
+        msgs = [_msg("user", "Hello")]
+        # Walk up the hierarchy — every step should upgrade.
+        for tier_name in ("simple", "mid", "complex", "reasoning"):
+            _, tier, status = cache.upgrade_if_higher(msgs, f"m-{tier_name}", tier_name)
+            assert tier == tier_name
+            assert status in ("new", "upgraded")
+        # Now walking back down should keep "reasoning" at every step.
+        for tier_name in ("complex", "mid", "simple"):
+            model, tier, status = cache.upgrade_if_higher(
+                msgs, f"m-{tier_name}", tier_name
+            )
+            assert (model, tier, status) == ("m-reasoning", "reasoning", "kept")
+
+    def test_upgrade_if_higher_expired_entry_treated_as_missing(self):
+        """Stale (TTL-expired) high-tier entry must NOT block a fresh classification."""
+        import time
+        cache = SessionCache(ttl_seconds=60)
+        msgs = [_msg("user", "Hello")]
+        # Directly inject an entry whose timestamp is well past the TTL.
+        key = cache._make_key(msgs)
+        cache._cache[key] = ("claude-opus", "reasoning", time.time() - 3600)
+        # Even though "reasoning" outranks "simple", the stale entry should be
+        # discarded and the fresh classification should win.
+        model, tier, status = cache.upgrade_if_higher(msgs, "gpt-4o-mini", "simple")
+        assert (model, tier, status) == ("gpt-4o-mini", "simple", "new")
+        assert cache.get(msgs) == ("gpt-4o-mini", "simple")
+
+    def test_upgrade_if_higher_evicts_when_over_capacity(self):
+        """upgrade_if_higher must enforce max_size via LRU eviction."""
+        cache = SessionCache(ttl_seconds=60, max_size=3)
+        # Insert 5 distinct sessions — only the 3 most recent should remain.
+        for i in range(5):
+            cache.upgrade_if_higher([_msg("user", f"prompt-{i}")], f"m-{i}", "simple")
+        assert len(cache._cache) == 3
+        # The first two sessions should have been evicted.
+        assert cache.get([_msg("user", "prompt-0")]) is None
+        assert cache.get([_msg("user", "prompt-1")]) is None
+        # The most recent three should still be there.
+        assert cache.get([_msg("user", "prompt-4")]) == ("m-4", "simple")
+
+    def test_upgrade_if_higher_touch_updates_lru(self):
+        """Touching an entry via upgrade_if_higher should mark it as most-recently-used."""
+        cache = SessionCache(ttl_seconds=60, max_size=3)
+        msgs_a = [_msg("user", "A")]
+        msgs_b = [_msg("user", "B")]
+        msgs_c = [_msg("user", "C")]
+        cache.upgrade_if_higher(msgs_a, "m-a", "simple")
+        cache.upgrade_if_higher(msgs_b, "m-b", "simple")
+        cache.upgrade_if_higher(msgs_c, "m-c", "simple")
+        # Touch A by re-querying it via upgrade_if_higher (status='kept').
+        cache.upgrade_if_higher(msgs_a, "m-a-new", "simple")
+        # Now insert a 4th entry — B should be evicted (LRU), not A.
+        cache.upgrade_if_higher([_msg("user", "D")], "m-d", "simple")
+        assert cache.get(msgs_a) == ("m-a", "simple")
+        assert cache.get(msgs_b) is None  # evicted
+        assert cache.get(msgs_c) == ("m-c", "simple")
+
 
 # ---------------------------------------------------------------------------
 # estimate_cost


### PR DESCRIPTION
## Problem

When used with agent frameworks like OpenClaw, the session cache pins the routing tier based on the first message in a session. Since agent frameworks send large system prompts + tool schemas, the first classification often lands on "mid" — and the 30-minute TTL means every subsequent message (even genuinely complex ones) stays pinned to mid/sonnet.

This is the same class of issue that affects LiteLLM's `complexity_router` with tool-heavy payloads.

## Solution

**Upgrade-only session cache** — the cached tier can only escalate, never downgrade.

### Changes

- **Always classify** every request (no more cache-hit short-circuit)
- **New method `upgrade_if_higher()`** — atomically compares new tier against cached tier, upgrades if higher, keeps cached if equal or above
- **`put()` is upgrade-only** — skips write if cached tier already outranks the new one
- **TTL reduced** from 30min to 5min for faster session turnover
- **Tier hierarchy**: simple (0) < mid (1) < complex (2) < reasoning (3)

### Behavior

| Step | Classified | Cached | Used | |
|------|-----------|--------|------|-|
| 1 | simple | (none) | claw-quick | New session |
| 2 | complex | simple→complex | claw-reason | ✅ Upgraded |
| 3 | simple | complex | claw-reason | ✅ No downgrade |

### Tested with

- OpenClaw + NadirClaw + LiteLLM (3-tier: claw-quick / claw-chat / claw-reason)
- Verified: simple→quick, complex→reason, simple-after-complex→stays reason
- Streaming and non-streaming paths both work