### PR TITLE
feat(security): production security hardening — OWASP API Top 10

### DIFF
--- a/nadirclaw/auth.py
+++ b/nadirclaw/auth.py
@@ -5,6 +5,7 @@ Supports both Authorization: Bearer <token> and X-API-Key: <token>
 so any OpenAI-compatible client works out of the box.
 """
 
+import hmac
 import json
 import logging
 import os
@@ -102,14 +103,22 @@ async def validate_local_auth(
             detail="Missing auth token. Send Authorization: Bearer <token> or X-API-Key: <token>",
         )
 
-    user_data = _LOCAL_USERS.get(token)
-    if user_data is None:
+    # Constant-time token comparison to prevent timing side-channel attacks.
+    # Iterate all configured tokens so timing does not reveal which (or whether)
+    # a token exists in the dict.
+    matched_user_data = None
+    for candidate_token, candidate_data in _LOCAL_USERS.items():
+        if hmac.compare_digest(token.encode("utf-8"), candidate_token.encode("utf-8")):
+            matched_user_data = candidate_data
+            # Do NOT break — iterate all keys for constant-time behavior
+
+    if matched_user_data is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid auth token",
         )
 
-    return UserSession(user_data)
+    return UserSession(matched_user_data)
 
 
 def _default_user() -> Dict[str, Any]:

--- a/nadirclaw/credentials.py
+++ b/nadirclaw/credentials.py
@@ -6,6 +6,8 @@ Supports OAuth tokens with automatic refresh for all providers.
 OpenClaw integration is optional — NadirClaw works standalone.
 """
 
+import base64
+import hashlib
 import json
 import logging
 import os
@@ -16,6 +18,73 @@ from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger("nadirclaw")
+
+
+# ---------------------------------------------------------------------------
+# Credential encryption at rest (Fernet symmetric encryption)
+# ---------------------------------------------------------------------------
+
+def _get_encryption_key() -> Optional[bytes]:
+    """Derive a Fernet encryption key from NADIRCLAW_CREDENTIAL_KEY env var.
+
+    Returns None if no key is configured (plaintext fallback with warning).
+    """
+    raw_key = os.getenv("NADIRCLAW_CREDENTIAL_KEY", "")
+    if not raw_key:
+        return None
+    # Derive a 32-byte key from the user-provided secret via SHA-256,
+    # then base64url-encode it for Fernet compatibility.
+    derived = hashlib.sha256(raw_key.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(derived)
+
+
+def _encrypt_json(data: dict) -> str:
+    """Encrypt a dict as a Fernet token string. Falls back to plaintext."""
+    key = _get_encryption_key()
+    if key is None:
+        return json.dumps(data, indent=2)
+    try:
+        from cryptography.fernet import Fernet
+        f = Fernet(key)
+        plaintext = json.dumps(data).encode("utf-8")
+        return f.encrypt(plaintext).decode("ascii")
+    except ImportError:
+        logger.warning(
+            "cryptography package not installed — credentials stored in plaintext. "
+            "Install with: pip install cryptography"
+        )
+        return json.dumps(data, indent=2)
+
+
+def _decrypt_json(raw: str) -> dict:
+    """Decrypt a Fernet token string back to a dict. Falls back to plain JSON."""
+    # Try plain JSON first (migration path: old plaintext files still work)
+    raw_stripped = raw.strip()
+    if raw_stripped.startswith("{"):
+        data = json.loads(raw_stripped)
+        # Auto-migrate: if encryption key is now configured, re-encrypt on next write
+        return data
+
+    # Try Fernet decryption
+    key = _get_encryption_key()
+    if key is None:
+        # No key configured but file is encrypted — cannot read
+        logger.error(
+            "Credentials file appears encrypted but NADIRCLAW_CREDENTIAL_KEY is not set. "
+            "Set the same key used during encryption to decrypt."
+        )
+        return {}
+    try:
+        from cryptography.fernet import Fernet, InvalidToken
+        f = Fernet(key)
+        plaintext = f.decrypt(raw_stripped.encode("ascii"))
+        return json.loads(plaintext)
+    except ImportError:
+        logger.error("cryptography package required to decrypt credentials")
+        return {}
+    except (InvalidToken, Exception) as e:
+        logger.error("Failed to decrypt credentials (wrong key?): %s", e)
+        return {}
 
 # Provider name → env var mapping
 _ENV_VAR_MAP = {
@@ -63,7 +132,8 @@ def _read_credentials() -> dict:
     if not path.exists():
         return {}
     try:
-        return json.loads(path.read_text())
+        raw = path.read_text()
+        return _decrypt_json(raw)
     except (json.JSONDecodeError, OSError) as e:
         logger.warning("Could not read credentials file: %s", e)
         return {}
@@ -89,7 +159,7 @@ def _write_credentials(data: dict) -> None:
         )
         try:
             with os.fdopen(fd, "w") as f:
-                f.write(json.dumps(data, indent=2) + "\n")
+                f.write(_encrypt_json(data) + "\n")
             os.replace(tmp_path, str(path))
         except Exception:
             try:

--- a/nadirclaw/pii_redactor.py
+++ b/nadirclaw/pii_redactor.py
@@ -1,0 +1,126 @@
+"""
+PII redaction for LLM output.
+
+Scans LLM responses for common PII patterns (email, phone, SSN, credit card)
+and redacts them before returning to the user.
+
+Configuration:
+  NADIRCLAW_PII_REDACTION: "none" (default) | "log_only" | "redact"
+
+Designed to run on non-streaming responses only. Streaming responses
+cannot be reliably redacted due to partial regex matches across chunks.
+"""
+
+import logging
+import os
+import re
+from typing import Tuple
+
+logger = logging.getLogger("nadirclaw.pii_redactor")
+
+_MODE = os.getenv("NADIRCLAW_PII_REDACTION", "none").lower()
+
+# ---------------------------------------------------------------------------
+# PII patterns
+# ---------------------------------------------------------------------------
+
+# Email addresses
+_EMAIL_RE = re.compile(
+    r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
+)
+
+# US phone numbers (various formats)
+_PHONE_RE = re.compile(
+    r"(?<!\d)"  # No digit before
+    r"(?:\+?1[-.\s]?)?"  # Optional country code
+    r"(?:\(?\d{3}\)?[-.\s]?)"  # Area code
+    r"\d{3}[-.\s]?\d{4}"  # Number
+    r"(?!\d)"  # No digit after
+)
+
+# US Social Security Numbers
+_SSN_RE = re.compile(
+    r"\b\d{3}-\d{2}-\d{4}\b"
+)
+
+# Credit card numbers (basic pattern, Luhn-validated)
+_CC_RE = re.compile(
+    r"\b(?:\d{4}[-\s]?){3}\d{4}\b"
+)
+
+
+def _luhn_check(number: str) -> bool:
+    """Validate a credit card number using the Luhn algorithm."""
+    digits = [int(d) for d in number if d.isdigit()]
+    if len(digits) < 13 or len(digits) > 19:
+        return False
+    checksum = 0
+    for i, digit in enumerate(reversed(digits)):
+        if i % 2 == 1:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        checksum += digit
+    return checksum % 10 == 0
+
+
+_PATTERNS = [
+    ("email", _EMAIL_RE, "[REDACTED_EMAIL]"),
+    ("phone", _PHONE_RE, "[REDACTED_PHONE]"),
+    ("ssn", _SSN_RE, "[REDACTED_SSN]"),
+    ("credit_card", _CC_RE, "[REDACTED_CC]"),
+]
+
+
+def scan_pii(text: str) -> list[dict]:
+    """Scan text for PII patterns. Returns list of detected PII with type and location."""
+    findings = []
+    for pii_type, pattern, _ in _PATTERNS:
+        for match in pattern.finditer(text):
+            # Extra Luhn validation for credit cards
+            if pii_type == "credit_card":
+                if not _luhn_check(match.group(0)):
+                    continue
+            findings.append({
+                "type": pii_type,
+                "start": match.start(),
+                "end": match.end(),
+            })
+    return findings
+
+
+def redact_pii(text: str) -> Tuple[str, bool]:
+    """Redact PII from text based on configured mode.
+
+    Returns:
+        Tuple of (possibly_redacted_text, pii_was_found).
+    """
+    if _MODE == "none":
+        return text, False
+
+    findings = scan_pii(text)
+    if not findings:
+        return text, False
+
+    # Log findings
+    types_found = set(f["type"] for f in findings)
+    logger.warning("PII detected in LLM output: types=%s count=%d", types_found, len(findings))
+
+    if _MODE == "log_only":
+        return text, True
+
+    # Mode is "redact" — replace all PII matches
+    result = text
+    # Process in reverse order to preserve character offsets
+    for pii_type, pattern, replacement in _PATTERNS:
+        if pii_type == "credit_card":
+            # Luhn-validated replacement
+            def _cc_replacer(match):
+                if _luhn_check(match.group(0)):
+                    return replacement
+                return match.group(0)
+            result = pattern.sub(_cc_replacer, result)
+        else:
+            result = pattern.sub(replacement, result)
+
+    return result, True

--- a/nadirclaw/prompt_guard.py
+++ b/nadirclaw/prompt_guard.py
@@ -1,0 +1,200 @@
+"""
+Prompt injection detection for NadirClaw.
+
+Heuristic-based (Tier 1) detection of adversarial prompt injection patterns.
+Designed to catch direct and indirect injection without flagging legitimate
+agentic workflows (tool definitions, structured system prompts, multi-turn
+conversations).
+
+Action modes (set via NADIRCLAW_PROMPT_GUARD env var):
+  - "log"   (default): Log detection, do not block
+  - "warn":  Log + add X-Prompt-Guard-Warning response header
+  - "block": Return 400 Bad Request on detection
+"""
+
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+logger = logging.getLogger("nadirclaw.prompt_guard")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_ACTION = os.getenv("NADIRCLAW_PROMPT_GUARD", "log").lower()
+assert _ACTION in ("log", "warn", "block"), (
+    f"Invalid NADIRCLAW_PROMPT_GUARD={_ACTION!r}; expected log|warn|block"
+)
+
+# ---------------------------------------------------------------------------
+# Detection patterns
+#
+# IMPORTANT: These patterns target adversarial override attempts specifically.
+# They must NOT match legitimate agentic patterns like:
+#   - Tool definitions with "instructions" fields
+#   - Multi-turn conversations with assistant/system roles
+#   - Structured delimiters used in prompt templates
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InjectionSignal:
+    """A detected injection signal with confidence and context."""
+    pattern_name: str
+    matched_text: str
+    confidence: float  # 0.0 to 1.0
+    message_index: int  # Which message in the array
+
+
+# Case-insensitive patterns that strongly indicate prompt injection
+# Each tuple: (pattern_name, compiled_regex, confidence)
+_INJECTION_PATTERNS: List[tuple] = [
+    # Direct instruction override
+    (
+        "instruction_override",
+        re.compile(
+            r"(?:ignore|disregard|forget|override|bypass)\s+"
+            r"(?:all\s+)?(?:previous|above|prior|earlier|your|the)\s+"
+            r"(?:instructions?|rules?|prompts?|guidelines?|constraints?|context)",
+            re.IGNORECASE,
+        ),
+        0.95,
+    ),
+    # Role reassignment
+    (
+        "role_reassignment",
+        re.compile(
+            r"(?:you\s+are\s+now|from\s+now\s+on\s+you\s+are|"
+            r"act\s+as\s+if\s+you\s+are|pretend\s+(?:to\s+be|you\s+are)|"
+            r"i\s+want\s+you\s+to\s+(?:act|behave|respond)\s+as)",
+            re.IGNORECASE,
+        ),
+        0.80,
+    ),
+    # System prompt extraction
+    (
+        "prompt_extraction",
+        re.compile(
+            r"(?:repeat|show|reveal|display|print|output|leak|give\s+me|tell\s+me)\s+"
+            r"(?:your|the|all|entire)?\s*"
+            r"(?:system\s+(?:prompt|message|instructions?)|"
+            r"initial\s+(?:prompt|instructions?)|"
+            r"(?:hidden|secret)\s+(?:prompt|instructions?|rules?))",
+            re.IGNORECASE,
+        ),
+        0.90,
+    ),
+    # Role confusion in user message (embedding JSON role objects)
+    (
+        "role_confusion_json",
+        re.compile(
+            r'\{\s*"role"\s*:\s*"(?:system|assistant)"\s*,\s*"content"\s*:',
+            re.IGNORECASE,
+        ),
+        0.70,
+    ),
+    # Delimiter injection (attempting to break out of sandboxed context)
+    (
+        "delimiter_injection",
+        re.compile(
+            r"(?:^|\n)\s*(?:<\|(?:im_start|im_end|system|endoftext)\|>|"
+            r"\[INST\]|\[/INST\]|<<SYS>>|<</SYS>>|"
+            r"### (?:System|Human|Assistant|Instruction):)",
+            re.IGNORECASE | re.MULTILINE,
+        ),
+        0.85,
+    ),
+    # Encoded payload detection (base64 blocks that look like instructions)
+    (
+        "encoded_payload",
+        re.compile(
+            r"(?:decode|eval|execute|run)\s+(?:this|the\s+following)?\s*"
+            r"(?:base64|b64|encoded|hex)\s*[:\-]?\s*[A-Za-z0-9+/=]{40,}",
+            re.IGNORECASE,
+        ),
+        0.75,
+    ),
+    # "DAN" / jailbreak patterns
+    (
+        "jailbreak_dan",
+        re.compile(
+            r"(?:DAN\s+mode|Developer\s+Mode|(?:Do\s+)?Anything\s+Now|"
+            r"STAN\s+mode|anti-?DAN|maximum\s+mode|god\s+mode)",
+            re.IGNORECASE,
+        ),
+        0.90,
+    ),
+]
+
+
+def scan_messages(
+    messages: list,
+    threshold: float = 0.70,
+) -> Optional[InjectionSignal]:
+    """
+    Scan a list of ChatMessage objects for prompt injection signals.
+
+    Only scans user-role messages (system and assistant messages are trusted
+    in the agentic context — they come from the operator or the model itself).
+
+    Returns the highest-confidence signal above threshold, or None.
+    """
+    best_signal: Optional[InjectionSignal] = None
+
+    for idx, msg in enumerate(messages):
+        # Only scan user and tool messages — system/assistant are trusted
+        if msg.role not in ("user", "tool"):
+            continue
+
+        text = msg.text_content() if hasattr(msg, "text_content") else str(getattr(msg, "content", ""))
+        if not text:
+            continue
+
+        for pattern_name, regex, confidence in _INJECTION_PATTERNS:
+            match = regex.search(text)
+            if match and confidence >= threshold:
+                signal = InjectionSignal(
+                    pattern_name=pattern_name,
+                    matched_text=match.group(0)[:100],
+                    confidence=confidence,
+                    message_index=idx,
+                )
+                if best_signal is None or signal.confidence > best_signal.confidence:
+                    best_signal = signal
+
+    return best_signal
+
+
+def check_and_act(messages: list) -> Optional[InjectionSignal]:
+    """
+    Run prompt injection scan and take configured action.
+
+    Returns the signal if detected (caller should add header in "warn" mode
+    or return 400 in "block" mode).
+    """
+    signal = scan_messages(messages)
+    if signal is None:
+        return None
+
+    logger.warning(
+        "Prompt injection detected: pattern=%s confidence=%.2f msg_idx=%d matched=%r",
+        signal.pattern_name,
+        signal.confidence,
+        signal.message_index,
+        signal.matched_text,
+    )
+
+    return signal
+
+
+def should_block() -> bool:
+    """Whether the configured action is 'block'."""
+    return _ACTION == "block"
+
+
+def should_warn() -> bool:
+    """Whether the configured action is 'warn' (add header)."""
+    return _ACTION == "warn"

--- a/nadirclaw/replay_guard.py
+++ b/nadirclaw/replay_guard.py
@@ -1,0 +1,93 @@
+"""
+Opt-in replay attack prevention via request nonces.
+
+When a client sends `X-Request-Nonce`, we track it in-memory for a
+configurable window (default 300s). Duplicate nonces within the window
+are rejected with 409 Conflict.
+
+Clients that do NOT send the header are unaffected.
+
+Configuration:
+  NADIRCLAW_NONCE_WINDOW_SECS: dedup window (default 300)
+  NADIRCLAW_NONCE_MAX_SIZE: max stored nonces before eviction (default 50000)
+"""
+
+import logging
+import os
+import time
+import threading
+from collections import OrderedDict
+from typing import Optional
+
+logger = logging.getLogger("nadirclaw.replay_guard")
+
+_WINDOW_SECS = int(os.getenv("NADIRCLAW_NONCE_WINDOW_SECS", "300"))
+_MAX_SIZE = int(os.getenv("NADIRCLAW_NONCE_MAX_SIZE", "50000"))
+
+
+class NonceStore:
+    """Thread-safe in-memory nonce deduplication store with TTL eviction."""
+
+    def __init__(self, window_secs: int = _WINDOW_SECS, max_size: int = _MAX_SIZE):
+        self._lock = threading.Lock()
+        self._nonces: OrderedDict[str, float] = OrderedDict()
+        self._window = window_secs
+        self._max_size = max_size
+
+    def check_and_store(self, nonce: str) -> bool:
+        """
+        Check if a nonce is fresh (not seen before within the window).
+
+        Returns True if the nonce is fresh (request should proceed).
+        Returns False if the nonce is a duplicate (request should be rejected).
+        """
+        now = time.time()
+
+        with self._lock:
+            # Evict expired entries (oldest first, thanks to OrderedDict)
+            while self._nonces:
+                oldest_key, oldest_time = next(iter(self._nonces.items()))
+                if now - oldest_time > self._window:
+                    self._nonces.pop(oldest_key)
+                else:
+                    break
+
+            # Evict oldest if at capacity
+            while len(self._nonces) >= self._max_size:
+                self._nonces.popitem(last=False)
+
+            # Check for duplicate
+            if nonce in self._nonces:
+                logger.warning("Replay detected: duplicate nonce %s", nonce[:32])
+                return False
+
+            # Store the nonce
+            self._nonces[nonce] = now
+            return True
+
+
+# Global singleton
+_store = NonceStore()
+
+
+def check_nonce(nonce: Optional[str]) -> Optional[str]:
+    """
+    Check a request nonce for replay.
+
+    Args:
+        nonce: The X-Request-Nonce header value (None if not provided).
+
+    Returns:
+        None if the request should proceed.
+        An error message string if the request is a replay.
+    """
+    if nonce is None:
+        return None  # Opt-in: no nonce = no replay checking
+
+    if not nonce or len(nonce) > 256:
+        return "Invalid nonce format"
+
+    if not _store.check_and_store(nonce):
+        return "Duplicate request nonce (possible replay)"
+
+    return None

--- a/nadirclaw/request_logger.py
+++ b/nadirclaw/request_logger.py
@@ -112,7 +112,9 @@ def log_request(entry: Dict[str, Any]) -> None:
     request_id = entry.get("request_id")
     req_type = entry.get("type")
     status = entry.get("status", "ok")
-    prompt = entry.get("prompt")
+    # Truncate prompt to prevent storing sensitive system prompt content
+    _raw_prompt = entry.get("prompt")
+    prompt = _raw_prompt[:500] if isinstance(_raw_prompt, str) else _raw_prompt
     selected_model = entry.get("selected_model")
     provider = entry.get("provider")
     tier = entry.get("tier")

--- a/nadirclaw/request_signing.py
+++ b/nadirclaw/request_signing.py
@@ -1,0 +1,88 @@
+"""
+HMAC request signing/verification for internal service-to-service communication.
+
+Signs outbound requests and verifies inbound signatures to prevent
+request tampering and replay attacks.
+
+Headers:
+  X-Signature: HMAC-SHA256 hex digest
+  X-Timestamp: Unix epoch seconds
+
+Configuration:
+  NADIRCLAW_INTERNAL_HMAC_SECRET: shared secret (required)
+  NADIRCLAW_HMAC_CLOCK_SKEW_SECS: max allowed clock skew (default 300)
+"""
+
+import hashlib
+import hmac as hmac_mod
+import logging
+import os
+import time
+from typing import Optional, Tuple
+
+logger = logging.getLogger("nadirclaw.request_signing")
+
+_HMAC_SECRET: Optional[str] = os.getenv("NADIRCLAW_INTERNAL_HMAC_SECRET")
+_MAX_CLOCK_SKEW_SECS: int = int(os.getenv("NADIRCLAW_HMAC_CLOCK_SKEW_SECS", "300"))
+
+
+def sign_request(method: str, path: str, body: bytes) -> Optional[Tuple[str, int]]:
+    """Compute HMAC-SHA256 signature for an outbound request.
+
+    Returns (signature_hex, timestamp) or None if no secret is configured.
+    """
+    if not _HMAC_SECRET:
+        return None
+
+    timestamp = int(time.time())
+    body_hash = hashlib.blake2b(body, digest_size=32).hexdigest()
+    signing_string = f"{method}\n{path}\n{timestamp}\n{body_hash}"
+
+    signature = hmac_mod.new(
+        _HMAC_SECRET.encode("utf-8"),
+        signing_string.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    return (signature, timestamp)
+
+
+def verify_request(
+    method: str,
+    path: str,
+    body: bytes,
+    signature_header: str,
+    timestamp_header: str,
+) -> Optional[str]:
+    """Verify an inbound HMAC-SHA256 signature.
+
+    Returns None if valid, or an error message string.
+    """
+    if not _HMAC_SECRET:
+        return "HMAC verification failed: no secret configured"
+
+    # Parse timestamp
+    try:
+        timestamp = int(timestamp_header)
+    except (ValueError, TypeError):
+        return "HMAC verification failed: invalid timestamp"
+
+    # Check clock skew (replay prevention)
+    now = int(time.time())
+    if abs(now - timestamp) > _MAX_CLOCK_SKEW_SECS:
+        return "HMAC verification failed: request too old (possible replay)"
+
+    # Recompute signature
+    body_hash = hashlib.blake2b(body, digest_size=32).hexdigest()
+    signing_string = f"{method}\n{path}\n{timestamp}\n{body_hash}"
+
+    expected = hmac_mod.new(
+        _HMAC_SECRET.encode("utf-8"),
+        signing_string.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    # Constant-time comparison
+    if hmac_mod.compare_digest(expected, signature_header):
+        return None
+    return "HMAC verification failed: signature mismatch"

--- a/nadirclaw/server.py
+++ b/nadirclaw/server.py
@@ -19,8 +19,10 @@ from typing import Any, Dict, List, Optional, Union
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from sse_starlette.sse import EventSourceResponse
+
+import os
 
 from nadirclaw import __version__
 from nadirclaw.auth import UserSession, validate_local_auth
@@ -91,17 +93,62 @@ app = FastAPI(
 from nadirclaw.web_dashboard import router as dashboard_router
 app.include_router(dashboard_router)
 
+# ---------------------------------------------------------------------------
+# CORS — restrict to explicit origins (never wildcard + credentials)
+# ---------------------------------------------------------------------------
+_cors_origins_raw = os.getenv("NADIRCLAW_CORS_ORIGINS", "")
+if _cors_origins_raw:
+    _cors_origins = [o.strip() for o in _cors_origins_raw.split(",") if o.strip()]
+    _cors_credentials = True
+else:
+    # Local-only default: only localhost origins
+    _cors_origins = [
+        "http://localhost:*",
+        "http://127.0.0.1:*",
+        "https://localhost:*",
+        "https://127.0.0.1:*",
+    ]
+    _cors_credentials = False  # No credentials unless origins are explicitly configured
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=_cors_origins,
+    allow_credentials=_cors_credentials,
+    allow_methods=["GET", "POST", "HEAD", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type", "X-API-Key", "X-Request-ID"],
 )
 
 
 # ---------------------------------------------------------------------------
-# Validation error handler — log request body for debugging
+# Security headers middleware
+# ---------------------------------------------------------------------------
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Inject security headers on every response."""
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["X-Request-ID"] = str(uuid.uuid4())
+        # Prevent caching of API responses
+        if request.url.path.startswith("/v1/"):
+            response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
+        if os.getenv("NADIRCLAW_HSTS", "").lower() in ("1", "true", "yes"):
+            response.headers["Strict-Transport-Security"] = (
+                "max-age=31536000; includeSubDomains"
+            )
+        return response
+
+
+app.add_middleware(SecurityHeadersMiddleware)
+
+
+# ---------------------------------------------------------------------------
+# Validation error handler — sanitized responses (no Pydantic internals)
 # ---------------------------------------------------------------------------
 
 from fastapi.exceptions import RequestValidationError
@@ -110,14 +157,24 @@ from fastapi.exceptions import RequestValidationError
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     body = await request.body()
+    # Log full details server-side only
     logger.error(
-        "Validation error on %s %s: %s\nBody: %s",
+        "Validation error on %s %s: %s\nBody (truncated): %s",
         request.method,
         request.url.path,
         exc.errors(),
-        body[:2000].decode("utf-8", errors="replace"),
+        body[:500].decode("utf-8", errors="replace"),
     )
-    return JSONResponse(status_code=422, content={"detail": exc.errors()})
+    # Return sanitized error to client — no Pydantic internals
+    safe_errors = []
+    for err in exc.errors():
+        loc = err.get("loc", [])
+        field = ".".join(str(part) for part in loc if part != "body")
+        safe_errors.append({
+            "field": field or "request",
+            "message": f"Invalid value for '{field}'" if field else "Invalid request body",
+        })
+    return JSONResponse(status_code=422, content={"detail": safe_errors})
 
 
 # ---------------------------------------------------------------------------
@@ -153,6 +210,22 @@ class ChatCompletionRequest(BaseModel):
     max_tokens: Optional[int] = None
     top_p: Optional[float] = None
     stream: Optional[bool] = False
+    n: Optional[int] = None
+
+    @model_validator(mode="after")
+    def _validate_bounds(self) -> "ChatCompletionRequest":
+        """Enforce safe bounds on all numeric parameters."""
+        if len(self.messages) > 500:
+            raise ValueError("messages: max 500 messages allowed")
+        if self.temperature is not None and not (0.0 <= self.temperature <= 2.0):
+            raise ValueError("temperature: must be between 0.0 and 2.0")
+        if self.max_tokens is not None and (self.max_tokens < 1 or self.max_tokens > 100_000):
+            raise ValueError("max_tokens: must be between 1 and 100,000")
+        if self.top_p is not None and not (0.0 <= self.top_p <= 1.0):
+            raise ValueError("top_p: must be between 0.0 and 1.0")
+        if self.n is not None and (self.n < 1 or self.n > 8):
+            raise ValueError("n: must be between 1 and 8")
+        return self
 
 
 class ClassifyRequest(BaseModel):
@@ -169,10 +242,11 @@ class ClassifyBatchRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 _log_lock = Lock()
+_log_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="nadirclaw-log")
 
 
-def _log_request(entry: Dict[str, Any]) -> None:
-    """Append a JSON line to the request log and print to console."""
+def _log_request_sync(entry: Dict[str, Any]) -> None:
+    """Synchronous log writer — runs in thread pool to avoid blocking the event loop."""
     log_dir = settings.LOG_DIR
     log_dir.mkdir(parents=True, exist_ok=True)
     request_log = log_dir / "requests.jsonl"
@@ -183,13 +257,19 @@ def _log_request(entry: Dict[str, Any]) -> None:
         with open(request_log, "a") as f:
             f.write(line)
 
-    # Also log to SQLite
-    from nadirclaw.request_logger import log_request as sqlite_log
-    sqlite_log(entry)
 
-    # Update Prometheus metrics
-    from nadirclaw.metrics import record_request
-    record_request(entry)
+def _log_request(entry: Dict[str, Any]) -> None:
+    """Non-blocking log request — submits all blocking I/O to thread pool."""
+    def _do_log():
+        _log_request_sync(entry)
+        # SQLite logging (also blocking I/O with threading.Lock)
+        from nadirclaw.request_logger import log_request as sqlite_log
+        sqlite_log(entry)
+        # Prometheus metrics (CPU-only, fast)
+        from nadirclaw.metrics import record_request
+        record_request(entry)
+
+    _log_executor.submit(_do_log)
 
     tier = entry.get("tier", "?")
     model = entry.get("selected_model", "?")
@@ -220,6 +300,20 @@ def _extract_request_metadata(request: ChatCompletionRequest) -> Dict[str, Any]:
 
     system_text = " ".join(m.text_content() for m in system_msgs) if has_system else ""
 
+    # Sanitize system prompt for logging: redact API key patterns, truncate
+    import re
+    _API_KEY_PATTERN = re.compile(
+        r"(sk-[a-zA-Z0-9_-]{10,}|AIza[a-zA-Z0-9_-]{20,}|ghp_[a-zA-Z0-9]{20,}"
+        r"|gho_[a-zA-Z0-9]{20,}|xox[bpars]-[a-zA-Z0-9-]{10,})"
+    )
+    _log_system_prompts = os.getenv("NADIRCLAW_LOG_SYSTEM_PROMPTS", "false").lower() in (
+        "1", "true", "yes",
+    )
+    if _log_system_prompts and system_text:
+        sanitized_system_text = _API_KEY_PATTERN.sub("[REDACTED_KEY]", system_text)[:500]
+    else:
+        sanitized_system_text = ""
+
     from nadirclaw.routing import detect_images
     image_info = detect_images(messages)
 
@@ -228,7 +322,7 @@ def _extract_request_metadata(request: ChatCompletionRequest) -> Dict[str, Any]:
         "message_count": len(messages),
         "has_system_prompt": has_system,
         "system_prompt_length": system_len,
-        "system_prompt_text": system_text,
+        "system_prompt_text": sanitized_system_text,
         "has_tools": tool_count > 0,
         "tool_count": tool_count,
         "requested_model": request.model,
@@ -929,9 +1023,17 @@ def _rate_limit_error_response(model: str) -> Dict[str, Any]:
 
 @app.post("/v1/chat/completions")
 async def chat_completions(
+    raw_request: Request,
     request: ChatCompletionRequest,
     current_user: UserSession = Depends(validate_local_auth),
 ):
+    # --- Replay attack prevention (opt-in via X-Request-Nonce header) ---
+    from nadirclaw.replay_guard import check_nonce
+    nonce = raw_request.headers.get("x-request-nonce")
+    replay_err = check_nonce(nonce)
+    if replay_err:
+        raise HTTPException(status_code=409, detail=replay_err)
+
     # --- Rate limiting (per user) ---
     retry_after = _rate_limiter.check(current_user.id)
     if retry_after is not None:
@@ -948,6 +1050,15 @@ async def chat_completions(
             status_code=413,
             detail=f"Request content too large ({total_content_len:,} chars). "
                    f"Maximum is {_MAX_CONTENT_LENGTH:,} chars.",
+        )
+
+    # --- Prompt injection detection ---
+    from nadirclaw.prompt_guard import check_and_act, should_block, should_warn
+    _injection_signal = check_and_act(request.messages)
+    if _injection_signal and should_block():
+        raise HTTPException(
+            status_code=400,
+            detail="Request blocked: potential prompt injection detected",
         )
 
     start_time = time.time()
@@ -1229,7 +1340,14 @@ async def chat_completions(
         if "tool_calls" in response_data:
             message["tool_calls"] = response_data["tool_calls"]
 
-        return {
+        # --- PII redaction on LLM output (non-streaming only) ---
+        from nadirclaw.pii_redactor import redact_pii
+        if message.get("content"):
+            message["content"], pii_found = redact_pii(message["content"])
+            if pii_found:
+                logger.info("PII redacted from response for request %s", request_id)
+
+        response_body = {
             "id": request_id,
             "object": "chat.completion",
             "created": int(time.time()),
@@ -1252,6 +1370,12 @@ async def chat_completions(
                 "routing": analysis_info,
             },
         }
+
+        # Build JSONResponse with optional security headers
+        resp = JSONResponse(content=response_body)
+        if _injection_signal and should_warn():
+            resp.headers["X-Prompt-Guard-Warning"] = _injection_signal.pattern_name
+        return resp
 
     except HTTPException:
         raise  # Re-raise FastAPI HTTP exceptions as-is


### PR DESCRIPTION
## Summary

Comprehensive security audit and hardening of the `/v1/chat/completions` endpoint for production launch at 5k-10k RPM, targeting OWASP API Security Top 10 compliance.

### Critical Fixes
- **CORS**: Replaced `allow_origins=["*"]` + `allow_credentials=True` with explicit origin allowlist — eliminates credential theft from malicious cross-origin sites
- **Auth**: Constant-time token comparison via `hmac.compare_digest` — prevents timing side-channel brute-force
- **Security headers**: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy`, `Cache-Control: no-store`, opt-in HSTS
- **Validation errors**: Sanitized — no longer leaks Pydantic internals to clients
- **System prompt logging**: API key pattern redaction + 500-char truncation + opt-in
- **Input validation**: Bounds on messages (500), max_tokens (100K), temperature (0-2), top_p (0-1), n (1-8)

### New Security Modules
- **prompt_guard.py**: 7 heuristic injection patterns, configurable log/warn/block with response header
- **pii_redactor.py**: Email/phone/SSN/credit card (Luhn) redaction, configurable none/log_only/redact
- **replay_guard.py**: Opt-in `X-Request-Nonce` deduplication with 300s TTL
- **request_signing.py**: HMAC-SHA256 for service-to-service integrity
- **credentials.py**: Fernet encryption at rest with auto-migration from plaintext

### Performance Fix
- Replaced `threading.Lock` blocking event loop with `ThreadPoolExecutor` for all logging I/O

## Test plan
- [ ] Verify CORS: `curl -H "Origin: https://evil.com"` returns no ACAO header
- [ ] Verify security headers present on `/v1/chat/completions` responses
- [ ] Verify validation errors return sanitized messages (no Pydantic internals)
- [ ] Test prompt injection patterns are detected and logged
- [ ] Test PII redaction with `NADIRCLAW_PII_REDACTION=redact`
- [ ] Test replay guard rejects duplicate `X-Request-Nonce`
- [ ] Load test at 1K RPM to verify no event loop blocking from logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)