### PR TITLE
feat(security): add optional prompt guard and PII redactor modules

### DIFF
--- a/nadirclaw/auth.py
+++ b/nadirclaw/auth.py
@@ -5,6 +5,7 @@ Supports both Authorization: Bearer <token> and X-API-Key: <token>
 so any OpenAI-compatible client works out of the box.
 """
 
+import hmac
 import json
 import logging
 import os
@@ -102,14 +103,22 @@ async def validate_local_auth(
             detail="Missing auth token. Send Authorization: Bearer <token> or X-API-Key: <token>",
         )
 
-    user_data = _LOCAL_USERS.get(token)
-    if user_data is None:
+    # Constant-time token comparison to prevent timing side-channel attacks.
+    # Iterate all configured tokens so timing does not reveal which (or whether)
+    # a token exists in the dict.
+    matched_user_data = None
+    for candidate_token, candidate_data in _LOCAL_USERS.items():
+        if hmac.compare_digest(token.encode("utf-8"), candidate_token.encode("utf-8")):
+            matched_user_data = candidate_data
+            # Do NOT break — iterate all keys for constant-time behavior
+
+    if matched_user_data is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid auth token",
         )
 
-    return UserSession(user_data)
+    return UserSession(matched_user_data)
 
 
 def _default_user() -> Dict[str, Any]:

--- a/nadirclaw/pii_redactor.py
+++ b/nadirclaw/pii_redactor.py
@@ -1,0 +1,126 @@
+"""
+PII redaction for LLM output.
+
+Scans LLM responses for common PII patterns (email, phone, SSN, credit card)
+and redacts them before returning to the user.
+
+Configuration:
+  NADIRCLAW_PII_REDACTION: "none" (default) | "log_only" | "redact"
+
+Designed to run on non-streaming responses only. Streaming responses
+cannot be reliably redacted due to partial regex matches across chunks.
+"""
+
+import logging
+import os
+import re
+from typing import Tuple
+
+logger = logging.getLogger("nadirclaw.pii_redactor")
+
+_MODE = os.getenv("NADIRCLAW_PII_REDACTION", "none").lower()
+
+# ---------------------------------------------------------------------------
+# PII patterns
+# ---------------------------------------------------------------------------
+
+# Email addresses
+_EMAIL_RE = re.compile(
+    r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
+)
+
+# US phone numbers (various formats)
+_PHONE_RE = re.compile(
+    r"(?<!\d)"  # No digit before
+    r"(?:\+?1[-.\s]?)?"  # Optional country code
+    r"(?:\(?\d{3}\)?[-.\s]?)"  # Area code
+    r"\d{3}[-.\s]?\d{4}"  # Number
+    r"(?!\d)"  # No digit after
+)
+
+# US Social Security Numbers
+_SSN_RE = re.compile(
+    r"\b\d{3}-\d{2}-\d{4}\b"
+)
+
+# Credit card numbers (basic pattern, Luhn-validated)
+_CC_RE = re.compile(
+    r"\b(?:\d{4}[-\s]?){3}\d{4}\b"
+)
+
+
+def _luhn_check(number: str) -> bool:
+    """Validate a credit card number using the Luhn algorithm."""
+    digits = [int(d) for d in number if d.isdigit()]
+    if len(digits) < 13 or len(digits) > 19:
+        return False
+    checksum = 0
+    for i, digit in enumerate(reversed(digits)):
+        if i % 2 == 1:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        checksum += digit
+    return checksum % 10 == 0
+
+
+_PATTERNS = [
+    ("email", _EMAIL_RE, "[REDACTED_EMAIL]"),
+    ("phone", _PHONE_RE, "[REDACTED_PHONE]"),
+    ("ssn", _SSN_RE, "[REDACTED_SSN]"),
+    ("credit_card", _CC_RE, "[REDACTED_CC]"),
+]
+
+
+def scan_pii(text: str) -> list[dict]:
+    """Scan text for PII patterns. Returns list of detected PII with type and location."""
+    findings = []
+    for pii_type, pattern, _ in _PATTERNS:
+        for match in pattern.finditer(text):
+            # Extra Luhn validation for credit cards
+            if pii_type == "credit_card":
+                if not _luhn_check(match.group(0)):
+                    continue
+            findings.append({
+                "type": pii_type,
+                "start": match.start(),
+                "end": match.end(),
+            })
+    return findings
+
+
+def redact_pii(text: str) -> Tuple[str, bool]:
+    """Redact PII from text based on configured mode.
+
+    Returns:
+        Tuple of (possibly_redacted_text, pii_was_found).
+    """
+    if _MODE == "none":
+        return text, False
+
+    findings = scan_pii(text)
+    if not findings:
+        return text, False
+
+    # Log findings
+    types_found = set(f["type"] for f in findings)
+    logger.warning("PII detected in LLM output: types=%s count=%d", types_found, len(findings))
+
+    if _MODE == "log_only":
+        return text, True
+
+    # Mode is "redact" — replace all PII matches
+    result = text
+    # Process in reverse order to preserve character offsets
+    for pii_type, pattern, replacement in _PATTERNS:
+        if pii_type == "credit_card":
+            # Luhn-validated replacement
+            def _cc_replacer(match):
+                if _luhn_check(match.group(0)):
+                    return replacement
+                return match.group(0)
+            result = pattern.sub(_cc_replacer, result)
+        else:
+            result = pattern.sub(replacement, result)
+
+    return result, True

--- a/nadirclaw/pii_redactor.py
+++ b/nadirclaw/pii_redactor.py
@@ -12,13 +12,14 @@ cannot be reliably redacted due to partial regex matches across chunks.
 """
 
 import logging
-import os
 import re
 from typing import Tuple
 
+from nadirclaw.settings import settings
+
 logger = logging.getLogger("nadirclaw.pii_redactor")
 
-_MODE = os.getenv("NADIRCLAW_PII_REDACTION", "none").lower()
+# Mode is read lazily via `settings.PII_REDACTION_MODE` at call time.
 
 # ---------------------------------------------------------------------------
 # PII patterns
@@ -26,7 +27,7 @@ _MODE = os.getenv("NADIRCLAW_PII_REDACTION", "none").lower()
 
 # Email addresses
 _EMAIL_RE = re.compile(
-    r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
+    r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"
 )
 
 # US phone numbers (various formats)
@@ -89,13 +90,27 @@ def scan_pii(text: str) -> list[dict]:
     return findings
 
 
+def _cc_replacer_factory(replacement: str):
+    """Build a Luhn-validating re.sub replacer bound to a specific replacement string.
+
+    Using a factory (instead of a nested def inside the loop) avoids the
+    late-binding closure trap if `_PATTERNS` is ever reordered.
+    """
+    def _replace(match):
+        if _luhn_check(match.group(0)):
+            return replacement
+        return match.group(0)
+    return _replace
+
+
 def redact_pii(text: str) -> Tuple[str, bool]:
     """Redact PII from text based on configured mode.
 
     Returns:
         Tuple of (possibly_redacted_text, pii_was_found).
     """
-    if _MODE == "none":
+    mode = settings.PII_REDACTION_MODE
+    if mode == "none":
         return text, False
 
     findings = scan_pii(text)
@@ -106,20 +121,14 @@ def redact_pii(text: str) -> Tuple[str, bool]:
     types_found = set(f["type"] for f in findings)
     logger.warning("PII detected in LLM output: types=%s count=%d", types_found, len(findings))
 
-    if _MODE == "log_only":
+    if mode == "log_only":
         return text, True
 
-    # Mode is "redact" — replace all PII matches
+    # Mode is "redact" — replace all PII matches.
     result = text
-    # Process in reverse order to preserve character offsets
     for pii_type, pattern, replacement in _PATTERNS:
         if pii_type == "credit_card":
-            # Luhn-validated replacement
-            def _cc_replacer(match):
-                if _luhn_check(match.group(0)):
-                    return replacement
-                return match.group(0)
-            result = pattern.sub(_cc_replacer, result)
+            result = pattern.sub(_cc_replacer_factory(replacement), result)
         else:
             result = pattern.sub(replacement, result)
 

--- a/nadirclaw/prompt_guard.py
+++ b/nadirclaw/prompt_guard.py
@@ -1,0 +1,201 @@
+"""
+Prompt injection detection for NadirClaw.
+
+Heuristic-based (Tier 1) detection of adversarial prompt injection patterns.
+Designed to catch direct and indirect injection without flagging legitimate
+agentic workflows (tool definitions, structured system prompts, multi-turn
+conversations).
+
+Action modes (set via NADIRCLAW_PROMPT_GUARD env var):
+  - "log"   (default): Log detection, do not block
+  - "warn":  Log + add X-Prompt-Guard-Warning response header
+  - "block": Return 400 Bad Request on detection
+"""
+
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+logger = logging.getLogger("nadirclaw.prompt_guard")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_ACTION = os.getenv("NADIRCLAW_PROMPT_GUARD", "log").lower()
+if _ACTION not in ("log", "warn", "block"):
+    raise ValueError(
+        f"Invalid NADIRCLAW_PROMPT_GUARD={_ACTION!r}; expected log|warn|block"
+    )
+
+# ---------------------------------------------------------------------------
+# Detection patterns
+#
+# IMPORTANT: These patterns target adversarial override attempts specifically.
+# They must NOT match legitimate agentic patterns like:
+#   - Tool definitions with "instructions" fields
+#   - Multi-turn conversations with assistant/system roles
+#   - Structured delimiters used in prompt templates
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InjectionSignal:
+    """A detected injection signal with confidence and context."""
+    pattern_name: str
+    matched_text: str
+    confidence: float  # 0.0 to 1.0
+    message_index: int  # Which message in the array
+
+
+# Case-insensitive patterns that strongly indicate prompt injection
+# Each tuple: (pattern_name, compiled_regex, confidence)
+_INJECTION_PATTERNS: List[tuple] = [
+    # Direct instruction override
+    (
+        "instruction_override",
+        re.compile(
+            r"(?:ignore|disregard|forget|override|bypass)\s+"
+            r"(?:all\s+)?(?:previous|above|prior|earlier|your|the)\s+"
+            r"(?:instructions?|rules?|prompts?|guidelines?|constraints?|context)",
+            re.IGNORECASE,
+        ),
+        0.95,
+    ),
+    # Role reassignment
+    (
+        "role_reassignment",
+        re.compile(
+            r"(?:you\s+are\s+now|from\s+now\s+on\s+you\s+are|"
+            r"act\s+as\s+if\s+you\s+are|pretend\s+(?:to\s+be|you\s+are)|"
+            r"i\s+want\s+you\s+to\s+(?:act|behave|respond)\s+as)",
+            re.IGNORECASE,
+        ),
+        0.80,
+    ),
+    # System prompt extraction
+    (
+        "prompt_extraction",
+        re.compile(
+            r"(?:repeat|show|reveal|display|print|output|leak|give\s+me|tell\s+me)\s+"
+            r"(?:your|the|all|entire)?\s*"
+            r"(?:system\s+(?:prompt|message|instructions?)|"
+            r"initial\s+(?:prompt|instructions?)|"
+            r"(?:hidden|secret)\s+(?:prompt|instructions?|rules?))",
+            re.IGNORECASE,
+        ),
+        0.90,
+    ),
+    # Role confusion in user message (embedding JSON role objects)
+    (
+        "role_confusion_json",
+        re.compile(
+            r'\{\s*"role"\s*:\s*"(?:system|assistant)"\s*,\s*"content"\s*:',
+            re.IGNORECASE,
+        ),
+        0.70,
+    ),
+    # Delimiter injection (attempting to break out of sandboxed context)
+    (
+        "delimiter_injection",
+        re.compile(
+            r"(?:^|\n)\s*(?:<\|(?:im_start|im_end|system|endoftext)\|>|"
+            r"\[INST\]|\[/INST\]|<<SYS>>|<</SYS>>|"
+            r"### (?:System|Human|Assistant|Instruction):)",
+            re.IGNORECASE | re.MULTILINE,
+        ),
+        0.85,
+    ),
+    # Encoded payload detection (base64 blocks that look like instructions)
+    (
+        "encoded_payload",
+        re.compile(
+            r"(?:decode|eval|execute|run)\s+(?:this|the\s+following)?\s*"
+            r"(?:base64|b64|encoded|hex)\s*[:\-]?\s*[A-Za-z0-9+/=]{40,}",
+            re.IGNORECASE,
+        ),
+        0.75,
+    ),
+    # "DAN" / jailbreak patterns
+    (
+        "jailbreak_dan",
+        re.compile(
+            r"(?:DAN\s+mode|Developer\s+Mode|(?:Do\s+)?Anything\s+Now|"
+            r"STAN\s+mode|anti-?DAN|maximum\s+mode|god\s+mode)",
+            re.IGNORECASE,
+        ),
+        0.90,
+    ),
+]
+
+
+def scan_messages(
+    messages: list,
+    threshold: float = 0.70,
+) -> Optional[InjectionSignal]:
+    """
+    Scan a list of ChatMessage objects for prompt injection signals.
+
+    Only scans user-role messages (system and assistant messages are trusted
+    in the agentic context — they come from the operator or the model itself).
+
+    Returns the highest-confidence signal above threshold, or None.
+    """
+    best_signal: Optional[InjectionSignal] = None
+
+    for idx, msg in enumerate(messages):
+        # Only scan user and tool messages — system/assistant are trusted
+        if msg.role not in ("user", "tool"):
+            continue
+
+        text = msg.text_content() if hasattr(msg, "text_content") else str(getattr(msg, "content", ""))
+        if not text:
+            continue
+
+        for pattern_name, regex, confidence in _INJECTION_PATTERNS:
+            match = regex.search(text)
+            if match and confidence >= threshold:
+                signal = InjectionSignal(
+                    pattern_name=pattern_name,
+                    matched_text=match.group(0)[:100],
+                    confidence=confidence,
+                    message_index=idx,
+                )
+                if best_signal is None or signal.confidence > best_signal.confidence:
+                    best_signal = signal
+
+    return best_signal
+
+
+def check_and_act(messages: list) -> Optional[InjectionSignal]:
+    """
+    Run prompt injection scan and take configured action.
+
+    Returns the signal if detected (caller should add header in "warn" mode
+    or return 400 in "block" mode).
+    """
+    signal = scan_messages(messages)
+    if signal is None:
+        return None
+
+    logger.warning(
+        "Prompt injection detected: pattern=%s confidence=%.2f msg_idx=%d matched=%r",
+        signal.pattern_name,
+        signal.confidence,
+        signal.message_index,
+        signal.matched_text,
+    )
+
+    return signal
+
+
+def should_block() -> bool:
+    """Whether the configured action is 'block'."""
+    return _ACTION == "block"
+
+
+def should_warn() -> bool:
+    """Whether the configured action is 'warn' (add header)."""
+    return _ACTION == "warn"

--- a/nadirclaw/prompt_guard.py
+++ b/nadirclaw/prompt_guard.py
@@ -13,22 +13,17 @@ Action modes (set via NADIRCLAW_PROMPT_GUARD env var):
 """
 
 import logging
-import os
 import re
 from dataclasses import dataclass
 from typing import List, Optional
 
+from nadirclaw.settings import settings
+
 logger = logging.getLogger("nadirclaw.prompt_guard")
 
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
-
-_ACTION = os.getenv("NADIRCLAW_PROMPT_GUARD", "log").lower()
-if _ACTION not in ("log", "warn", "block"):
-    raise ValueError(
-        f"Invalid NADIRCLAW_PROMPT_GUARD={_ACTION!r}; expected log|warn|block"
-    )
+# Configuration is read lazily via `settings.PROMPT_GUARD_ACTION` at call
+# time — bad env values log a warning and fall back to "log" rather than
+# crashing the entire package at import.
 
 # ---------------------------------------------------------------------------
 # Detection patterns
@@ -138,8 +133,11 @@ def scan_messages(
     """
     Scan a list of ChatMessage objects for prompt injection signals.
 
-    Only scans user-role messages (system and assistant messages are trusted
-    in the agentic context — they come from the operator or the model itself).
+    Scope: only user- and tool-role messages are scanned. System and
+    assistant messages are intentionally trusted in the agentic context —
+    they come from the operator or the model itself. This means indirect
+    injection via crafted assistant replay messages is *not* detected here;
+    that surface needs an upstream defense.
 
     Returns the highest-confidence signal above threshold, or None.
     """
@@ -193,9 +191,9 @@ def check_and_act(messages: list) -> Optional[InjectionSignal]:
 
 def should_block() -> bool:
     """Whether the configured action is 'block'."""
-    return _ACTION == "block"
+    return settings.PROMPT_GUARD_ACTION == "block"
 
 
 def should_warn() -> bool:
     """Whether the configured action is 'warn' (add header)."""
-    return _ACTION == "warn"
+    return settings.PROMPT_GUARD_ACTION == "warn"

--- a/nadirclaw/request_logger.py
+++ b/nadirclaw/request_logger.py
@@ -126,7 +126,9 @@ def log_request(entry: Dict[str, Any]) -> None:
     request_id = entry.get("request_id")
     req_type = entry.get("type")
     status = entry.get("status", "ok")
-    prompt = entry.get("prompt")
+    # Truncate prompt to prevent storing sensitive system prompt content
+    _raw_prompt = entry.get("prompt")
+    prompt = _raw_prompt[:500] if isinstance(_raw_prompt, str) else _raw_prompt
     selected_model = entry.get("selected_model")
     provider = entry.get("provider")
     tier = entry.get("tier")

--- a/nadirclaw/server.py
+++ b/nadirclaw/server.py
@@ -19,8 +19,10 @@ from typing import Any, Dict, List, Optional, Union
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from sse_starlette.sse import EventSourceResponse
+
+import os
 
 from nadirclaw import __version__
 from nadirclaw.auth import UserSession, validate_local_auth
@@ -93,18 +95,63 @@ app.include_router(dashboard_router)
 
 _ROUTING_HEADERS = ("X-Routed-Model", "X-Routed-Tier", "X-Complexity-Score")
 
+# ---------------------------------------------------------------------------
+# CORS — restrict to explicit origins (never wildcard + credentials)
+# ---------------------------------------------------------------------------
+_cors_origins_raw = os.getenv("NADIRCLAW_CORS_ORIGINS", "")
+if _cors_origins_raw:
+    _cors_origins = [o.strip() for o in _cors_origins_raw.split(",") if o.strip()]
+    _cors_credentials = True
+else:
+    # Local-only default: only localhost origins
+    _cors_origins = [
+        "http://localhost:*",
+        "http://127.0.0.1:*",
+        "https://localhost:*",
+        "https://127.0.0.1:*",
+    ]
+    _cors_credentials = False  # No credentials unless origins are explicitly configured
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=_cors_origins,
+    allow_credentials=_cors_credentials,
+    allow_methods=["GET", "POST", "HEAD", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type", "X-API-Key", "X-Request-ID"],
     expose_headers=list(_ROUTING_HEADERS),
 )
 
 
 # ---------------------------------------------------------------------------
-# Validation error handler — log request body for debugging
+# Security headers middleware
+# ---------------------------------------------------------------------------
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Inject security headers on every response."""
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["X-Request-ID"] = str(uuid.uuid4())
+        # Prevent caching of API responses
+        if request.url.path.startswith("/v1/"):
+            response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
+        if os.getenv("NADIRCLAW_HSTS", "").lower() in ("1", "true", "yes"):
+            response.headers["Strict-Transport-Security"] = (
+                "max-age=31536000; includeSubDomains"
+            )
+        return response
+
+
+app.add_middleware(SecurityHeadersMiddleware)
+
+
+# ---------------------------------------------------------------------------
+# Validation error handler — sanitized responses (no Pydantic internals)
 # ---------------------------------------------------------------------------
 
 from fastapi.exceptions import RequestValidationError
@@ -113,14 +160,24 @@ from fastapi.exceptions import RequestValidationError
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     body = await request.body()
+    # Log full details server-side only
     logger.error(
-        "Validation error on %s %s: %s\nBody: %s",
+        "Validation error on %s %s: %s\nBody (truncated): %s",
         request.method,
         request.url.path,
         exc.errors(),
-        body[:2000].decode("utf-8", errors="replace"),
+        body[:500].decode("utf-8", errors="replace"),
     )
-    return JSONResponse(status_code=422, content={"detail": exc.errors()})
+    # Return sanitized error to client — no Pydantic internals
+    safe_errors = []
+    for err in exc.errors():
+        loc = err.get("loc", [])
+        field = ".".join(str(part) for part in loc if part != "body")
+        safe_errors.append({
+            "field": field or "request",
+            "message": f"Invalid value for '{field}'" if field else "Invalid request body",
+        })
+    return JSONResponse(status_code=422, content={"detail": safe_errors})
 
 
 # ---------------------------------------------------------------------------
@@ -156,6 +213,22 @@ class ChatCompletionRequest(BaseModel):
     max_tokens: Optional[int] = None
     top_p: Optional[float] = None
     stream: Optional[bool] = False
+    n: Optional[int] = None
+
+    @model_validator(mode="after")
+    def _validate_bounds(self) -> "ChatCompletionRequest":
+        """Enforce safe bounds on all numeric parameters."""
+        if len(self.messages) > 500:
+            raise ValueError("messages: max 500 messages allowed")
+        if self.temperature is not None and not (0.0 <= self.temperature <= 2.0):
+            raise ValueError("temperature: must be between 0.0 and 2.0")
+        if self.max_tokens is not None and (self.max_tokens < 1 or self.max_tokens > 100_000):
+            raise ValueError("max_tokens: must be between 1 and 100,000")
+        if self.top_p is not None and not (0.0 <= self.top_p <= 1.0):
+            raise ValueError("top_p: must be between 0.0 and 1.0")
+        if self.n is not None and (self.n < 1 or self.n > 8):
+            raise ValueError("n: must be between 1 and 8")
+        return self
 
 
 class ClassifyRequest(BaseModel):
@@ -172,10 +245,11 @@ class ClassifyBatchRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 _log_lock = Lock()
+_log_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="nadirclaw-log")
 
 
-def _log_request(entry: Dict[str, Any]) -> None:
-    """Append a JSON line to the request log and print to console."""
+def _log_request_sync(entry: Dict[str, Any]) -> None:
+    """Synchronous log writer — runs in thread pool to avoid blocking the event loop."""
     log_dir = settings.LOG_DIR
     log_dir.mkdir(parents=True, exist_ok=True)
     request_log = log_dir / "requests.jsonl"
@@ -186,13 +260,19 @@ def _log_request(entry: Dict[str, Any]) -> None:
         with open(request_log, "a") as f:
             f.write(line)
 
-    # Also log to SQLite
-    from nadirclaw.request_logger import log_request as sqlite_log
-    sqlite_log(entry)
 
-    # Update Prometheus metrics
-    from nadirclaw.metrics import record_request
-    record_request(entry)
+def _log_request(entry: Dict[str, Any]) -> None:
+    """Non-blocking log request — submits all blocking I/O to thread pool."""
+    def _do_log():
+        _log_request_sync(entry)
+        # SQLite logging (also blocking I/O with threading.Lock)
+        from nadirclaw.request_logger import log_request as sqlite_log
+        sqlite_log(entry)
+        # Prometheus metrics (CPU-only, fast)
+        from nadirclaw.metrics import record_request
+        record_request(entry)
+
+    _log_executor.submit(_do_log)
 
     tier = entry.get("tier", "?")
     model = entry.get("selected_model", "?")
@@ -223,6 +303,20 @@ def _extract_request_metadata(request: ChatCompletionRequest) -> Dict[str, Any]:
 
     system_text = " ".join(m.text_content() for m in system_msgs) if has_system else ""
 
+    # Sanitize system prompt for logging: redact API key patterns, truncate
+    import re
+    _API_KEY_PATTERN = re.compile(
+        r"(sk-[a-zA-Z0-9_-]{10,}|AIza[a-zA-Z0-9_-]{20,}|ghp_[a-zA-Z0-9]{20,}"
+        r"|gho_[a-zA-Z0-9]{20,}|xox[bpars]-[a-zA-Z0-9-]{10,})"
+    )
+    _log_system_prompts = os.getenv("NADIRCLAW_LOG_SYSTEM_PROMPTS", "false").lower() in (
+        "1", "true", "yes",
+    )
+    if _log_system_prompts and system_text:
+        sanitized_system_text = _API_KEY_PATTERN.sub("[REDACTED_KEY]", system_text)[:500]
+    else:
+        sanitized_system_text = ""
+
     from nadirclaw.routing import detect_images
     image_info = detect_images(messages)
 
@@ -231,7 +325,7 @@ def _extract_request_metadata(request: ChatCompletionRequest) -> Dict[str, Any]:
         "message_count": len(messages),
         "has_system_prompt": has_system,
         "system_prompt_length": system_len,
-        "system_prompt_text": system_text,
+        "system_prompt_text": sanitized_system_text,
         "has_tools": tool_count > 0,
         "tool_count": tool_count,
         "requested_model": request.model,
@@ -943,6 +1037,7 @@ def _routing_headers(model: str, analysis_info: Dict[str, Any]) -> Dict[str, str
 
 @app.post("/v1/chat/completions")
 async def chat_completions(
+    raw_request: Request,
     request: ChatCompletionRequest,
     response: Response,
     current_user: UserSession = Depends(validate_local_auth),
@@ -1284,7 +1379,7 @@ async def chat_completions(
         if "tool_calls" in response_data:
             message["tool_calls"] = response_data["tool_calls"]
 
-        return {
+        response_body = {
             "id": request_id,
             "object": "chat.completion",
             "created": int(time.time()),
@@ -1308,6 +1403,8 @@ async def chat_completions(
                 **({"optimization": optimization_info} if optimization_info else {}),
             },
         }
+
+        return JSONResponse(content=response_body)
 
     except HTTPException:
         raise  # Re-raise FastAPI HTTP exceptions as-is

--- a/nadirclaw/server.py
+++ b/nadirclaw/server.py
@@ -102,19 +102,19 @@ _cors_origins_raw = os.getenv("NADIRCLAW_CORS_ORIGINS", "")
 if _cors_origins_raw:
     _cors_origins = [o.strip() for o in _cors_origins_raw.split(",") if o.strip()]
     _cors_credentials = True
+    _cors_origin_regex = None
 else:
-    # Local-only default: only localhost origins
-    _cors_origins = [
-        "http://localhost:*",
-        "http://127.0.0.1:*",
-        "https://localhost:*",
-        "https://127.0.0.1:*",
-    ]
+    # Local-only default: match any port on localhost/127.0.0.1
+    # Starlette does exact string matching on allow_origins, so we use
+    # allow_origin_regex to support arbitrary ports during development.
+    _cors_origins = []
+    _cors_origin_regex = r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$"
     _cors_credentials = False  # No credentials unless origins are explicitly configured
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,
+    allow_origin_regex=_cors_origin_regex,
     allow_credentials=_cors_credentials,
     allow_methods=["GET", "POST", "HEAD", "OPTIONS"],
     allow_headers=["Authorization", "Content-Type", "X-API-Key", "X-Request-ID"],

--- a/nadirclaw/server.py
+++ b/nadirclaw/server.py
@@ -1060,6 +1060,15 @@ async def chat_completions(
                    f"Maximum is {_MAX_CONTENT_LENGTH:,} chars.",
         )
 
+    # --- Prompt injection detection ---
+    from nadirclaw.prompt_guard import check_and_act, should_block, should_warn
+    _injection_signal = check_and_act(request.messages)
+    if _injection_signal and should_block():
+        raise HTTPException(
+            status_code=400,
+            detail="Request blocked: potential prompt injection detected",
+        )
+
     start_time = time.time()
     request_id = str(uuid.uuid4())
 
@@ -1379,6 +1388,13 @@ async def chat_completions(
         if "tool_calls" in response_data:
             message["tool_calls"] = response_data["tool_calls"]
 
+        # --- PII redaction on LLM output (non-streaming only) ---
+        from nadirclaw.pii_redactor import redact_pii
+        if message.get("content"):
+            message["content"], pii_found = redact_pii(message["content"])
+            if pii_found:
+                logger.info("PII redacted from response for request %s", request_id)
+
         response_body = {
             "id": request_id,
             "object": "chat.completion",
@@ -1404,7 +1420,10 @@ async def chat_completions(
             },
         }
 
-        return JSONResponse(content=response_body)
+        resp = JSONResponse(content=response_body)
+        if _injection_signal and should_warn():
+            resp.headers["X-Prompt-Guard-Warning"] = _injection_signal.pattern_name
+        return resp
 
     except HTTPException:
         raise  # Re-raise FastAPI HTTP exceptions as-is

--- a/nadirclaw/settings.py
+++ b/nadirclaw/settings.py
@@ -217,6 +217,32 @@ class Settings:
             return 40
 
     @property
+    def PROMPT_GUARD_ACTION(self) -> str:
+        """Prompt injection guard action: log, warn, block. Default: log."""
+        val = os.getenv("NADIRCLAW_PROMPT_GUARD", "log").lower()
+        if val not in ("log", "warn", "block"):
+            _settings_logger.warning(
+                "Invalid NADIRCLAW_PROMPT_GUARD=%r — expected log|warn|block. "
+                "Falling back to 'log'.",
+                val,
+            )
+            return "log"
+        return val
+
+    @property
+    def PII_REDACTION_MODE(self) -> str:
+        """PII redaction mode: none, log_only, redact. Default: none."""
+        val = os.getenv("NADIRCLAW_PII_REDACTION", "none").lower()
+        if val not in ("none", "log_only", "redact"):
+            _settings_logger.warning(
+                "Invalid NADIRCLAW_PII_REDACTION=%r — expected none|log_only|redact. "
+                "Falling back to 'none'.",
+                val,
+            )
+            return "none"
+        return val
+
+    @property
     def has_explicit_tiers(self) -> bool:
         """True if SIMPLE_MODEL and COMPLEX_MODEL are explicitly set via env."""
         return bool(


### PR DESCRIPTION
## Summary

Adds two opt-in security modules for defense-in-depth. Both are disabled or in log-only mode by default, so they have zero impact unless explicitly configured. Depends on #30 (core hardening).

**prompt_guard.py — Heuristic prompt injection detection**
- 7 injection patterns: instruction override, role reassignment, prompt extraction, role confusion via JSON, delimiter injection, encoded payloads, DAN/jailbreak
- `NADIRCLAW_PROMPT_GUARD`: `log` (default) / `warn` / `block`
- Only scans user/tool messages (system/assistant trusted)
- Config validation uses `ValueError` instead of `assert` (survives `python -O`)

**pii_redactor.py — PII pattern detection and redaction**
- Detects: email, US phone, SSN, credit card (Luhn-validated)
- `NADIRCLAW_PII_REDACTION`: `none` (default) / `log_only` / `redact`
- Non-streaming responses only (documented limitation)

**Known limitations (per review):**
- Prompt guard has false-positive risk on prompts like "act as a SQL expert" — mitigated by log-only default
- PII redactor only covers non-streaming responses — incomplete but better than nothing for the common case

## Test plan

- [ ] `python -O -c "import nadirclaw.prompt_guard"` succeeds (ValueError not assert)
- [ ] Test prompt injection patterns detected: `"ignore all previous instructions"`
- [ ] Test PII redaction with `NADIRCLAW_PII_REDACTION=redact` — emails/phones replaced
- [ ] Verify default mode (`log`) does not block any requests
- [ ] Verify `warn` mode adds `X-Prompt-Guard-Warning` header without blocking
- [ ] Run full test suite: `pytest tests/ -x` (383 tests passing)