### PR TITLE
fix: return real token counts in streaming responses

### DIFF
--- a/nadirclaw/server.py
+++ b/nadirclaw/server.py
@@ -1445,7 +1445,12 @@ async def _stream_litellm(
             msg["name"] = extra_fields["name"]
         messages.append(msg)
 
-    call_kwargs: Dict[str, Any] = {"model": litellm_model, "messages": messages, "stream": True}
+    call_kwargs: Dict[str, Any] = {
+        "model": litellm_model,
+        "messages": messages,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
     if request.temperature is not None:
         call_kwargs["temperature"] = request.temperature
     if request.max_tokens is not None:
@@ -1478,9 +1483,20 @@ async def _stream_litellm(
         raise
 
     async for chunk in response:
+        usage = None
+        if hasattr(chunk, "usage") and chunk.usage:
+            usage = {
+                "prompt_tokens": chunk.usage.prompt_tokens or 0,
+                "completion_tokens": chunk.usage.completion_tokens or 0,
+            }
+
         choice = chunk.choices[0] if chunk.choices else None
         if choice is None:
+            # Usage-only final chunk (no choices) -- yield usage without content
+            if usage:
+                yield {}, usage, None
             continue
+
         delta = choice.delta
         delta_dict: dict[str, Any] = {}
         if hasattr(delta, "role") and delta.role:
@@ -1492,13 +1508,6 @@ async def _stream_litellm(
                 tc.model_dump() if hasattr(tc, "model_dump") else tc
                 for tc in delta.tool_calls
             ]
-
-        usage = None
-        if hasattr(chunk, "usage") and chunk.usage:
-            usage = {
-                "prompt_tokens": chunk.usage.prompt_tokens or 0,
-                "completion_tokens": chunk.usage.completion_tokens or 0,
-            }
 
         yield delta_dict, usage, choice.finish_reason
 


### PR DESCRIPTION
## Summary

- Streaming responses (`stream: true`) always returned `usage: {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}` in the final SSE chunk, breaking token/cost tracking in downstream clients like OpenCode
- Added `stream_options: {"include_usage": True}` to the LiteLLM `acompletion()` call
- Reordered usage extraction in `_stream_litellm()` to capture usage-only final chunks (empty `choices`) that were silently dropped

## Details

**Bug 1 — Missing `stream_options`** (`server.py:1448`)

The LiteLLM call set `stream: True` but never passed `stream_options: {"include_usage": True}`, so the upstream provider never included token counts in streaming chunks.

**Bug 2 — Usage-only chunks discarded** (`server.py:1485-1488`)

Some providers send a final chunk with usage data but empty `choices`. The `if choice is None: continue` guard dropped these before usage could be extracted. Fixed by moving usage extraction before the guard and yielding usage-only chunks.

## Verification

```
Before: "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
After:  "usage": {"prompt_tokens": 40, "completion_tokens": 10, "total_tokens": 50}
```

## Test plan

- [ ] Verify streaming responses include real token counts with LiteLLM-backed models
- [ ] Verify non-streaming responses still work (unchanged code path)
- [ ] Verify OpenCode/other OpenAI-compatible clients display correct usage stats
- [ ] Verify Gemini streaming path is unaffected (separate function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)