### PR TITLE
feat: model pool weighted load balancing

### DIFF
--- a/nadirclaw/routing.py
+++ b/nadirclaw/routing.py
@@ -6,6 +6,8 @@ model aliases, context-window filtering, and session persistence.
 
 import hashlib
 import logging
+import os
+import random
 import re
 import time
 from collections import OrderedDict
@@ -13,6 +15,91 @@ from threading import Lock
 from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger("nadirclaw.routing")
+
+# ---------------------------------------------------------------------------
+# Model Pool — weighted load balancing across multiple models
+# ---------------------------------------------------------------------------
+
+def _parse_model_pools() -> Dict[str, List[Tuple[str, int]]]:
+    """Parse NADIRCLAW_MODEL_POOLS env var into pool configuration.
+
+    Format: "pool_name=model1,weight1+model2,weight2;pool_name2=..."
+    Example: "turbo=gemini-2.5-flash,10+gpt-4.1-nano,5;reasoning=gpt-5.2,8+claude-opus-4-6-20250918,4"
+    """
+    raw = os.getenv("NADIRCLAW_MODEL_POOLS", "")
+    if not raw:
+        return {}
+    pools: Dict[str, List[Tuple[str, int]]] = {}
+    for pool_def in raw.split(";"):
+        pool_def = pool_def.strip()
+        if not pool_def or "=" not in pool_def:
+            continue
+        pool_name, _, models_str = pool_def.partition("=")
+        pool_name = pool_name.strip()
+        if not pool_name or not models_str:
+            continue
+        entries: List[Tuple[str, int]] = []
+        for entry in models_str.split("+"):
+            entry = entry.strip()
+            if not entry:
+                continue
+            segs = entry.rsplit(",", 1)
+            if len(segs) == 2:
+                model_name = segs[0].strip()
+                try:
+                    weight = max(1, int(segs[1].strip()))
+                except ValueError:
+                    weight = 1
+            else:
+                model_name = segs[0].strip()
+                weight = 1
+            if model_name:
+                entries.append((model_name, weight))
+        if entries:
+            pools[pool_name] = entries
+    return pools
+
+
+MODEL_POOLS: Dict[str, List[Tuple[str, int]]] = _parse_model_pools()
+
+# Reverse map: model name → pool name
+_MODEL_TO_POOL: Dict[str, str] = {}
+for _pool_name, _models in MODEL_POOLS.items():
+    for _model_name, _ in _models:
+        _MODEL_TO_POOL[_model_name] = _pool_name
+
+
+def select_from_pool(pool_name: str) -> str:
+    """Select a model from the pool using weighted random selection.
+
+    Args:
+        pool_name: Name of the pool (e.g., "turbo", "reasoning").
+
+    Returns:
+        Selected model name, or the first model in the pool as fallback.
+    """
+    pool = MODEL_POOLS.get(pool_name)
+    if not pool:
+        logger.warning("Unknown model pool: %s", pool_name)
+        return ""
+    models, weights = zip(*pool)
+    total_weight = sum(weights)
+    r = random.randint(1, total_weight)
+    cumulative = 0
+    for model, weight in pool:
+        cumulative += weight
+        if r <= cumulative:
+            logger.debug(
+                "Pool %s selected: %s (weight=%d, rand=%d/%d)",
+                pool_name, model, weight, r, total_weight,
+            )
+            return model
+    return pool[0][0]
+
+
+def get_pool_for_model(model: str) -> Optional[str]:
+    """Return the pool name for a given model, or None if not in any pool."""
+    return _MODEL_TO_POOL.get(model)
 
 # ---------------------------------------------------------------------------
 # Model registry — context windows and capabilities
@@ -549,6 +636,23 @@ def apply_routing_modifiers(
                 "Context window exceeded for all models (est=%d tokens). Proceeding with %s.",
                 estimated, final_model,
             )
+
+    # --- Model Pool Selection ---
+    # If the final model belongs to a pool, select from the pool based on weights.
+    # Skip pool override for tiers where the model was explicitly chosen by reasoning
+    # or agentic detection — pool selection is for load-balancing equivalent models.
+    pool_name = get_pool_for_model(final_model)
+    if pool_name and final_tier not in ("complex", "reasoning"):
+        original_model = final_model
+        final_model = select_from_pool(pool_name)
+        if final_model != original_model:
+            routing_info["modifiers_applied"].append(
+                f"pool_selection({pool_name}: {original_model}→{final_model})"
+            )
+            logger.info(
+                "Model pool %s: %s → %s", pool_name, original_model, final_model,
+            )
+        routing_info["pool_name"] = pool_name
 
     routing_info["final_model"] = final_model
     routing_info["final_tier"] = final_tier

--- a/nadirclaw/routing.py
+++ b/nadirclaw/routing.py
@@ -20,16 +20,24 @@ logger = logging.getLogger("nadirclaw.routing")
 # Model Pool — weighted load balancing across multiple models
 # ---------------------------------------------------------------------------
 
-def _parse_model_pools() -> Dict[str, List[Tuple[str, int]]]:
-    """Parse NADIRCLAW_MODEL_POOLS env var into pool configuration.
+# Lazy-initialized: pools are built on first access, not at import time,
+# so CLI `serve --set NADIRCLAW_MODEL_POOLS=...` works correctly.
+_MODEL_POOLS_CACHE: Optional[Dict[str, List[Tuple[str, int]]]] = None
+_MODEL_TO_POOL_CACHE: Optional[Dict[str, str]] = None
+_POOL_LOCK = Lock()
+
+
+def _parse_model_pools() -> Tuple[Dict[str, List[Tuple[str, int]]], Dict[str, str]]:
+    """Parse NADIRCLAW_MODEL_POOLS env var into pool + reverse-map.
 
     Format: "pool_name=model1,weight1+model2,weight2;pool_name2=..."
     Example: "turbo=gemini-2.5-flash,10+gpt-4.1-nano,5;reasoning=gpt-5.2,8+claude-opus-4-6-20250918,4"
     """
     raw = os.getenv("NADIRCLAW_MODEL_POOLS", "")
     if not raw:
-        return {}
+        return {}, {}
     pools: Dict[str, List[Tuple[str, int]]] = {}
+    reverse: Dict[str, str] = {}
     for pool_def in raw.split(";"):
         pool_def = pool_def.strip()
         if not pool_def or "=" not in pool_def:
@@ -55,18 +63,27 @@ def _parse_model_pools() -> Dict[str, List[Tuple[str, int]]]:
                 weight = 1
             if model_name:
                 entries.append((model_name, weight))
+                reverse[model_name] = pool_name
         if entries:
             pools[pool_name] = entries
-    return pools
+    return pools, reverse
 
 
-MODEL_POOLS: Dict[str, List[Tuple[str, int]]] = _parse_model_pools()
+def _ensure_pools_loaded() -> Tuple[Dict[str, List[Tuple[str, int]]], Dict[str, str]]:
+    """Lazily build and cache model pools on first routing call."""
+    global _MODEL_POOLS_CACHE, _MODEL_TO_POOL_CACHE
+    if _MODEL_POOLS_CACHE is None:
+        with _POOL_LOCK:
+            if _MODEL_POOLS_CACHE is None:
+                _MODEL_POOLS_CACHE, _MODEL_TO_POOL_CACHE = _parse_model_pools()
+    return _MODEL_POOLS_CACHE, _MODEL_TO_POOL_CACHE
 
-# Reverse map: model name → pool name
-_MODEL_TO_POOL: Dict[str, str] = {}
-for _pool_name, _models in MODEL_POOLS.items():
-    for _model_name, _ in _models:
-        _MODEL_TO_POOL[_model_name] = _pool_name
+
+def reload_pools() -> None:
+    """Force re-read of model pools from env (useful after serve --set)."""
+    global _MODEL_POOLS_CACHE, _MODEL_TO_POOL_CACHE
+    with _POOL_LOCK:
+        _MODEL_POOLS_CACHE, _MODEL_TO_POOL_CACHE = _parse_model_pools()
 
 
 def select_from_pool(pool_name: str) -> str:
@@ -76,14 +93,16 @@ def select_from_pool(pool_name: str) -> str:
         pool_name: Name of the pool (e.g., "turbo", "reasoning").
 
     Returns:
-        Selected model name, or the first model in the pool as fallback.
+        Selected model name.
+
+    Raises:
+        KeyError: If pool_name is not a configured pool.
     """
-    pool = MODEL_POOLS.get(pool_name)
+    pools, _ = _ensure_pools_loaded()
+    pool = pools.get(pool_name)
     if not pool:
-        logger.warning("Unknown model pool: %s", pool_name)
-        return ""
-    models, weights = zip(*pool)
-    total_weight = sum(weights)
+        raise KeyError(f"Unknown model pool: {pool_name!r}. Available: {list(pools.keys())}")
+    total_weight = sum(w for _, w in pool)
     r = random.randint(1, total_weight)
     cumulative = 0
     for model, weight in pool:
@@ -99,7 +118,8 @@ def select_from_pool(pool_name: str) -> str:
 
 def get_pool_for_model(model: str) -> Optional[str]:
     """Return the pool name for a given model, or None if not in any pool."""
-    return _MODEL_TO_POOL.get(model)
+    _, reverse = _ensure_pools_loaded()
+    return reverse.get(model)
 
 # ---------------------------------------------------------------------------
 # Model registry — context windows and capabilities

--- a/tests/test_model_pool.py
+++ b/tests/test_model_pool.py
@@ -1,0 +1,134 @@
+"""Tests for Model Pool weighted load balancing."""
+
+import os
+from unittest import mock
+
+import pytest
+
+from nadirclaw.routing import (
+    get_pool_for_model,
+    select_from_pool,
+    _parse_model_pools,
+)
+
+
+class TestParseModelPools:
+    """Tests for _parse_model_pools env var parsing."""
+
+    def test_empty_env(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            assert _parse_model_pools() == {}
+
+    def test_single_pool_single_model(self):
+        raw = "turbo=gemini-2.5-flash,10"
+        with mock.patch.dict(os.environ, {"NADIRCLAW_MODEL_POOLS": raw}):
+            pools = _parse_model_pools()
+            assert "turbo" in pools
+            assert pools["turbo"] == [("gemini-2.5-flash", 10)]
+
+    def test_single_pool_multiple_models(self):
+        raw = "turbo=gemini-2.5-flash,10+gpt-4.1-nano,5"
+        with mock.patch.dict(os.environ, {"NADIRCLAW_MODEL_POOLS": raw}):
+            pools = _parse_model_pools()
+            assert pools["turbo"] == [
+                ("gemini-2.5-flash", 10),
+                ("gpt-4.1-nano", 5),
+            ]
+
+    def test_multiple_pools(self):
+        raw = "turbo=gemini-2.5-flash,10;reasoning=gpt-5.2,8+claude-opus-4-6-20250918,4"
+        with mock.patch.dict(os.environ, {"NADIRCLAW_MODEL_POOLS": raw}):
+            pools = _parse_model_pools()
+            assert len(pools) == 2
+            assert pools["turbo"] == [("gemini-2.5-flash", 10)]
+            assert pools["reasoning"] == [
+                ("gpt-5.2", 8),
+                ("claude-opus-4-6-20250918", 4),
+            ]
+
+    def test_default_weight_is_one(self):
+        raw = "turbo=gemini-2.5-flash"
+        with mock.patch.dict(os.environ, {"NADIRCLAW_MODEL_POOLS": raw}):
+            pools = _parse_model_pools()
+            assert pools["turbo"] == [("gemini-2.5-flash", 1)]
+
+    def test_invalid_weight_uses_one(self):
+        raw = "turbo=gemini-2.5-flash,abc"
+        with mock.patch.dict(os.environ, {"NADIRCLAW_MODEL_POOLS": raw}):
+            pools = _parse_model_pools()
+            assert pools["turbo"] == [("gemini-2.5-flash", 1)]
+
+
+class TestSelectFromPool:
+    """Tests for weighted random selection."""
+
+    def _setup_pools(self):
+        """Set up test pools by patching the module-level variables."""
+        import nadirclaw.routing as routing_mod
+        test_pools = {
+            "balanced": [
+                ("model-a", 10),
+                ("model-b", 10),
+            ],
+            "single": [
+                ("only-model", 5),
+            ],
+        }
+        reverse_map = {}
+        for name, models in test_pools.items():
+            for m, _ in models:
+                reverse_map[m] = name
+
+        routing_mod.MODEL_POOLS = test_pools
+        routing_mod._MODEL_TO_POOL = reverse_map
+
+    def test_single_model_pool_always_returns_same(self):
+        self._setup_pools()
+        for _ in range(50):
+            assert select_from_pool("single") == "only-model"
+
+    def test_balanced_pool_returns_valid_model(self):
+        self._setup_pools()
+        valid = {"model-a", "model-b"}
+        for _ in range(50):
+            assert select_from_pool("balanced") in valid
+
+    def test_unknown_pool_returns_empty(self):
+        self._setup_pools()
+        assert select_from_pool("nonexistent") == ""
+
+    def test_weighted_distribution(self):
+        self._setup_pools()
+        import nadirclaw.routing as routing_mod
+        routing_mod.MODEL_POOLS = {
+            "heavy": [
+                ("heavy-model", 99),
+                ("light-model", 1),
+            ],
+        }
+        counts = {"heavy-model": 0, "light-model": 0}
+        for _ in range(1000):
+            counts[select_from_pool("heavy")] += 1
+        assert counts["heavy-model"] > counts["light-model"]
+
+
+class TestGetPoolForModel:
+    """Tests for reverse lookup: model → pool name."""
+
+    def _setup_pools(self):
+        import nadirclaw.routing as routing_mod
+        routing_mod.MODEL_POOLS = {
+            "turbo": [("gemini-2.5-flash", 10), ("gpt-4.1-nano", 5)],
+        }
+        routing_mod._MODEL_TO_POOL = {
+            "gemini-2.5-flash": "turbo",
+            "gpt-4.1-nano": "turbo",
+        }
+
+    def test_model_in_pool(self):
+        self._setup_pools()
+        assert get_pool_for_model("gemini-2.5-flash") == "turbo"
+
+    def test_model_not_in_pool(self):
+        self._setup_pools()
+        assert get_pool_for_model("claude-opus-4-6-20250918") is None

--- a/tests/test_model_pool.py
+++ b/tests/test_model_pool.py
@@ -17,19 +17,20 @@ class TestParseModelPools:
 
     def test_empty_env(self):
         with mock.patch.dict(os.environ, {}, clear=True):
-            assert _parse_model_pools() == {}
+            pools, _reverse = _parse_model_pools()
+            assert pools == {}
 
     def test_single_pool_single_model(self):
         raw = "turbo=gemini-2.5-flash,10"
         with mock.patch.dict(os.environ, {"NADIRCLAW_MODEL_POOLS": raw}):
-            pools = _parse_model_pools()
+            pools, _reverse = _parse_model_pools()
             assert "turbo" in pools
             assert pools["turbo"] == [("gemini-2.5-flash", 10)]
 
     def test_single_pool_multiple_models(self):
         raw = "turbo=gemini-2.5-flash,10+gpt-4.1-nano,5"
         with mock.patch.dict(os.environ, {"NADIRCLAW_MODEL_POOLS": raw}):
-            pools = _parse_model_pools()
+            pools, _reverse = _parse_model_pools()
             assert pools["turbo"] == [
                 ("gemini-2.5-flash", 10),
                 ("gpt-4.1-nano", 5),
@@ -38,24 +39,26 @@ class TestParseModelPools:
     def test_multiple_pools(self):
         raw = "turbo=gemini-2.5-flash,10;reasoning=gpt-5.2,8+claude-opus-4-6-20250918,4"
         with mock.patch.dict(os.environ, {"NADIRCLAW_MODEL_POOLS": raw}):
-            pools = _parse_model_pools()
+            pools, reverse = _parse_model_pools()
             assert len(pools) == 2
             assert pools["turbo"] == [("gemini-2.5-flash", 10)]
             assert pools["reasoning"] == [
                 ("gpt-5.2", 8),
                 ("claude-opus-4-6-20250918", 4),
             ]
+            assert reverse["gemini-2.5-flash"] == "turbo"
+            assert reverse["gpt-5.2"] == "reasoning"
 
     def test_default_weight_is_one(self):
         raw = "turbo=gemini-2.5-flash"
         with mock.patch.dict(os.environ, {"NADIRCLAW_MODEL_POOLS": raw}):
-            pools = _parse_model_pools()
+            pools, _reverse = _parse_model_pools()
             assert pools["turbo"] == [("gemini-2.5-flash", 1)]
 
     def test_invalid_weight_uses_one(self):
         raw = "turbo=gemini-2.5-flash,abc"
         with mock.patch.dict(os.environ, {"NADIRCLAW_MODEL_POOLS": raw}):
-            pools = _parse_model_pools()
+            pools, _reverse = _parse_model_pools()
             assert pools["turbo"] == [("gemini-2.5-flash", 1)]
 
 
@@ -63,7 +66,7 @@ class TestSelectFromPool:
     """Tests for weighted random selection."""
 
     def _setup_pools(self):
-        """Set up test pools by patching the module-level variables."""
+        """Set up test pools by patching the cache variables."""
         import nadirclaw.routing as routing_mod
         test_pools = {
             "balanced": [
@@ -79,8 +82,8 @@ class TestSelectFromPool:
             for m, _ in models:
                 reverse_map[m] = name
 
-        routing_mod.MODEL_POOLS = test_pools
-        routing_mod._MODEL_TO_POOL = reverse_map
+        routing_mod._MODEL_POOLS_CACHE = test_pools
+        routing_mod._MODEL_TO_POOL_CACHE = reverse_map
 
     def test_single_model_pool_always_returns_same(self):
         self._setup_pools()
@@ -93,14 +96,15 @@ class TestSelectFromPool:
         for _ in range(50):
             assert select_from_pool("balanced") in valid
 
-    def test_unknown_pool_returns_empty(self):
+    def test_unknown_pool_raises_keyerror(self):
         self._setup_pools()
-        assert select_from_pool("nonexistent") == ""
+        with pytest.raises(KeyError):
+            select_from_pool("nonexistent")
 
     def test_weighted_distribution(self):
         self._setup_pools()
         import nadirclaw.routing as routing_mod
-        routing_mod.MODEL_POOLS = {
+        routing_mod._MODEL_POOLS_CACHE = {
             "heavy": [
                 ("heavy-model", 99),
                 ("light-model", 1),
@@ -117,10 +121,10 @@ class TestGetPoolForModel:
 
     def _setup_pools(self):
         import nadirclaw.routing as routing_mod
-        routing_mod.MODEL_POOLS = {
+        routing_mod._MODEL_POOLS_CACHE = {
             "turbo": [("gemini-2.5-flash", 10), ("gpt-4.1-nano", 5)],
         }
-        routing_mod._MODEL_TO_POOL = {
+        routing_mod._MODEL_TO_POOL_CACHE = {
             "gemini-2.5-flash": "turbo",
             "gpt-4.1-nano": "turbo",
         }


### PR DESCRIPTION
## Summary

- Add **model pool** weighted load balancing for distributing requests across multiple equivalent models
- Pool configuration via `NADIRCLAW_MODEL_POOLS` environment variable
- Weighted random selection with configurable weights per model
- Integrated into `apply_routing_modifiers()` — applies after all other routing decisions

## Configuration

```env
NADIRCLAW_MODEL_POOLS=turbo=gemini-2.5-flash,10+gpt-4.1-nano,5;reasoning=gpt-5.2,8+claude-opus-4-6-20250918,4
```

Format: `pool_name=model,weight+model,weight;pool_name=model,weight+...`

## How it works

1. When a model is routed and belongs to a pool, weighted random selection picks from that pool
2. Skips pool selection for `complex` and `reasoning` tiers (models explicitly chosen by detection)
3. Only applies for load-balancing equivalent models in `simple`/`mid` tiers

## Testing

- 12 unit tests covering: env parsing, weighted selection, reverse lookup, edge cases
- All tests pass

## Use case

When running multiple equivalent models (e.g., different API providers for the same model, or multiple budget models), pools distribute load proportionally to their weights. This avoids hammering a single provider and provides basic load balancing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)