### PR TITLE
feat: agent role detection for AI coding assistants

### DIFF
--- a/nadirclaw/routing.py
+++ b/nadirclaw/routing.py
@@ -6,6 +6,7 @@ model aliases, context-window filtering, and session persistence.
 
 import hashlib
 import logging
+import os
 import re
 import time
 from collections import OrderedDict
@@ -256,6 +257,98 @@ def detect_reasoning(prompt: str, system_message: str = "") -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Agent role detection — identify AI coding agent session types
+# ---------------------------------------------------------------------------
+
+_PLANNING_MARKERS = re.compile(
+    r"(plan\s*mode\s*is\s*active"
+    r"|software\s+architect"
+    r"|planning\s+specialist"
+    r"|READ-ONLY.*planning"
+    r"|architect\s+agent"
+    r"|design.*implementation\s+plan)",
+    re.IGNORECASE,
+)
+
+_EXPLORE_MARKERS = re.compile(
+    r"(explore\s+agent"
+    r"|explore\s+codebase"
+    r"|fast\s+agent\s+specialized\s+for\s+exploring)",
+    re.IGNORECASE,
+)
+
+_SUBAGENT_MARKERS = re.compile(
+    r"(specialized\s+agent"
+    r"|subagent"
+    r"|background\s+agent"
+    r"|search\s+agent)",
+    re.IGNORECASE,
+)
+
+_EXECUTION_TOOLS = {
+    "Bash", "bash", "shell", "execute", "Write", "Edit",
+    "Task", "Run", "NotebookEdit",
+}
+
+
+def detect_agent_role(
+    system_prompt: str,
+    message_count: int = 0,
+    tool_names: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Detect the role/type of an AI coding agent session.
+
+    Examines the system prompt for markers that indicate whether this is a
+    planning session, an explore agent, a subagent, or a main execution session.
+
+    Returns {"role": str, "confidence": float, "signals": list[str]}.
+    Role can be: "planning", "explore", "subagent", or "unknown".
+    """
+    role = "unknown"
+    confidence = 0.0
+    signals: List[str] = []
+    tool_names = tool_names or []
+
+    if _PLANNING_MARKERS.search(system_prompt):
+        return {"role": "planning", "confidence": 0.95, "signals": ["planning_markers"]}
+
+    if _EXPLORE_MARKERS.search(system_prompt):
+        return {"role": "explore", "confidence": 0.95, "signals": ["explore_markers"]}
+
+    # Distinguish subagents from main sessions.
+    # Main sessions have long system prompts with extensive instructions.
+    is_main_session = len(system_prompt) > 15000
+
+    if not is_main_session and _SUBAGENT_MARKERS.search(system_prompt):
+        return {"role": "subagent", "confidence": 0.90, "signals": ["subagent_markers"]}
+
+    if not is_main_session and len(system_prompt) < 5000:
+        role = "subagent"
+        confidence = 0.50
+        signals.append("short_system_prompt")
+
+    return {"role": role, "confidence": confidence, "signals": signals}
+
+
+def _get_last_assistant_tool_calls(messages: List[Any]) -> List[str]:
+    """Extract tool names from the last assistant message with tool_use blocks."""
+    for msg in reversed(messages):
+        if getattr(msg, "role", "") != "assistant":
+            continue
+        content = getattr(msg, "content", [])
+        if not isinstance(content, list):
+            continue
+        calls = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                name = block.get("name", "")
+                if name:
+                    calls.append(name)
+        return calls
+    return []
+
+
+# ---------------------------------------------------------------------------
 # Context window check
 # ---------------------------------------------------------------------------
 
@@ -440,6 +533,116 @@ def estimate_cost(model: str, prompt_tokens: int, completion_tokens: int) -> Opt
 # Main routing modifier — applies all intelligence
 # ---------------------------------------------------------------------------
 
+def _apply_agent_role_routing(
+    agent_role: Dict[str, Any],
+    messages: List[Any],
+    final_model: str,
+    final_tier: str,
+    simple_model: str,
+    complex_model: str,
+    reasoning_model: Optional[str],
+    explore_model: Optional[str],
+    subagent_model: Optional[str],
+    free_model: Optional[str],
+    routing_info: Dict[str, Any],
+) -> None:
+    """Apply agent role-based routing decisions.
+
+    Mutates routing_info by setting final_model/final_tier and appending
+    modifiers. The caller reads these back and removes the temp keys.
+    """
+    role_type = agent_role.get("role", "unknown")
+    confidence = agent_role.get("confidence", 0.0)
+
+    if role_type == "planning" and confidence >= 0.90:
+        _route_planning_session(
+            messages, final_model, final_tier,
+            simple_model, complex_model, reasoning_model,
+            subagent_model, free_model, routing_info,
+        )
+    elif role_type == "explore" and confidence >= 0.90:
+        target = explore_model or complex_model
+        routing_info["modifiers_applied"].append("agent_role[EXPLORE]")
+        logger.info("Role routing [EXPLORE]: → %s", target)
+        routing_info["final_model"] = target
+        routing_info["final_tier"] = "explore"
+        return
+
+    elif role_type == "subagent" and confidence >= 0.60:
+        target = subagent_model or free_model or simple_model
+        if final_tier not in ("reasoning", "explore"):
+            routing_info["modifiers_applied"].append("agent_role[SUBAGENT]")
+            logger.info("Role routing [SUBAGENT]: → %s (conf=%.2f)", target, confidence)
+            routing_info["final_model"] = target
+            routing_info["final_tier"] = "subagent"
+            return
+
+    # No role override — pass through current values
+    routing_info["final_model"] = final_model
+    routing_info["final_tier"] = final_tier
+
+
+def _route_planning_session(
+    messages: List[Any],
+    final_model: str,
+    final_tier: str,
+    simple_model: str,
+    complex_model: str,
+    reasoning_model: Optional[str],
+    subagent_model: Optional[str],
+    free_model: Optional[str],
+    routing_info: Dict[str, Any],
+) -> None:
+    """Route planning sessions based on the driving phase.
+
+    Planning phases:
+    - USER: new user request (no tool result) → reasoning model for decision-making
+    - EXPLORATION: last tool call was exploration (Read, Glob, etc.) → fast model
+    - PLAN_GENERATION: last tool call was write/edit → reasoning model for quality
+    - CONTEXT: indeterminate → fast model (default)
+    """
+    last_message_is_tool = False
+    if messages:
+        last_message_is_tool = getattr(messages[-1], "role", "") == "tool"
+
+    last_tool_calls = _get_last_assistant_tool_calls(messages)
+    exploration_tools = {"Read", "Bash", "Glob", "Grep", "WebFetch", "WebSearch"}
+    plan_tools = {"Write", "Edit", "ExitPlanMode", "AskUserQuestion"}
+
+    called_exploration = bool(set(last_tool_calls) & exploration_tools)
+    called_plan = bool(set(last_tool_calls) & plan_tools)
+
+    use_reasoning = False
+    driver = "CONTEXT"
+
+    if not last_message_is_tool:
+        use_reasoning = True
+        driver = "USER"
+    elif called_plan:
+        use_reasoning = True
+        driver = "PLAN_GENERATION"
+    elif called_exploration:
+        use_reasoning = False
+        driver = "EXPLORATION"
+
+    if use_reasoning:
+        target = reasoning_model or complex_model
+        routing_info["modifiers_applied"].append(f"planning[{driver}]")
+        logger.info("Plan routing [%s]: → %s", driver, target)
+        routing_info["final_model"] = target
+        routing_info["final_tier"] = "reasoning"
+    else:
+        target = subagent_model or free_model or simple_model
+        routing_info["modifiers_applied"].append(f"planning[{driver}]")
+        logger.info("Plan routing [%s]: → %s", driver, target)
+        routing_info["final_model"] = target
+        routing_info["final_tier"] = "subagent"
+
+
+# ---------------------------------------------------------------------------
+# Main routing modifier — applies all intelligence
+# ---------------------------------------------------------------------------
+
 def apply_routing_modifiers(
     base_model: str,
     base_tier: str,
@@ -449,6 +652,8 @@ def apply_routing_modifiers(
     complex_model: str,
     reasoning_model: Optional[str] = None,
     free_model: Optional[str] = None,
+    explore_model: Optional[str] = None,
+    subagent_model: Optional[str] = None,
 ) -> Tuple[str, str, Dict[str, Any]]:
     """Apply all routing modifiers on top of the classifier's base decision.
 
@@ -462,6 +667,18 @@ def apply_routing_modifiers(
 
     final_model = base_model
     final_tier = base_tier
+
+    # --- Agent role detection ---
+    system_text = request_meta.get("system_prompt_text", "")
+    tool_names = request_meta.get("tool_names", [])
+    message_count = request_meta.get("message_count", 0)
+
+    agent_role = detect_agent_role(
+        system_prompt=system_text,
+        message_count=message_count,
+        tool_names=tool_names,
+    )
+    routing_info["agent_role"] = agent_role
 
     # --- Agentic detection ---
     agentic = detect_agentic(
@@ -507,6 +724,19 @@ def apply_routing_modifiers(
                 "Reasoning override: → %s (markers=%d: %s)",
                 target, reasoning["marker_count"], reasoning["markers"],
             )
+
+    # --- Agent role-based routing ---
+    _apply_agent_role_routing(
+        agent_role, messages, final_model, final_tier,
+        simple_model, complex_model, reasoning_model,
+        explore_model, subagent_model, free_model,
+        routing_info,
+    )
+    final_model = routing_info["final_model"]
+    final_tier = routing_info["final_tier"]
+    # Clean up temp keys set by _apply_agent_role_routing
+    routing_info.pop("final_model", None)
+    routing_info.pop("final_tier", None)
 
     # --- Vision detection ---
     if request_meta.get("has_images", False) and not has_vision(final_model):

--- a/nadirclaw/routing.py
+++ b/nadirclaw/routing.py
@@ -258,7 +258,22 @@ def detect_reasoning(prompt: str, system_message: str = "") -> Dict[str, Any]:
 
 # ---------------------------------------------------------------------------
 # Agent role detection — identify AI coding agent session types
+#
+# This feature is opt-in via NADIRCLAW_AGENT_ROLE_DETECTION=true.
+# It detects coding agent session types (planning, explore, subagent)
+# from system prompt markers. Currently tuned for Claude Code;
+# additional agent support welcome via PR.
+#
+# Markers are intentionally matched against system prompts only,
+# not user messages, to avoid false positives from career questions
+# or general discussion about software architecture.
 # ---------------------------------------------------------------------------
+
+# Named constants for session classification thresholds.
+# Claude Code's system prompt is ~35KB; Cursor varies.
+# Models with < MAIN_SESSION_MIN_CHARS are classified as subagents.
+MAIN_SESSION_MIN_CHARS = 15000  # chars — main session has long system prompt
+SHORT_SESSION_MAX_CHARS = 5000  # chars — likely a subagent/background task
 
 _PLANNING_MARKERS = re.compile(
     r"(plan\s*mode\s*is\s*active"
@@ -301,6 +316,8 @@ def detect_agent_role(
     Examines the system prompt for markers that indicate whether this is a
     planning session, an explore agent, a subagent, or a main execution session.
 
+    Currently tuned for Claude Code. Opt-in via NADIRCLAW_AGENT_ROLE_DETECTION=true.
+
     Returns {"role": str, "confidence": float, "signals": list[str]}.
     Role can be: "planning", "explore", "subagent", or "unknown".
     """
@@ -317,14 +334,14 @@ def detect_agent_role(
 
     # Distinguish subagents from main sessions.
     # Main sessions have long system prompts with extensive instructions.
-    is_main_session = len(system_prompt) > 15000
+    is_main_session = len(system_prompt) > MAIN_SESSION_MIN_CHARS
 
     if not is_main_session and _SUBAGENT_MARKERS.search(system_prompt):
         return {"role": "subagent", "confidence": 0.90, "signals": ["subagent_markers"]}
 
-    if not is_main_session and len(system_prompt) < 5000:
+    if not is_main_session and len(system_prompt) < SHORT_SESSION_MAX_CHARS:
         role = "subagent"
-        confidence = 0.50
+        confidence = 0.60  # Matches the routing threshold for subagent tier
         signals.append("short_system_prompt")
 
     return {"role": role, "confidence": confidence, "signals": signals}
@@ -673,12 +690,19 @@ def apply_routing_modifiers(
     tool_names = request_meta.get("tool_names", [])
     message_count = request_meta.get("message_count", 0)
 
-    agent_role = detect_agent_role(
-        system_prompt=system_text,
-        message_count=message_count,
-        tool_names=tool_names,
-    )
-    routing_info["agent_role"] = agent_role
+    # --- Agent role detection (opt-in) ---
+    # Detects coding agent session types (planning, explore, subagent).
+    # Disabled by default — enable with NADIRCLAW_AGENT_ROLE_DETECTION=true.
+    from nadirclaw.settings import settings as _settings
+    if _settings.AGENT_ROLE_DETECTION:
+        agent_role = detect_agent_role(
+            system_prompt=system_text,
+            message_count=message_count,
+            tool_names=tool_names,
+        )
+        routing_info["agent_role"] = agent_role
+    else:
+        routing_info["agent_role"] = {"role": "unknown", "confidence": 0.0, "signals": []}
 
     # --- Agentic detection ---
     agentic = detect_agentic(

--- a/nadirclaw/settings.py
+++ b/nadirclaw/settings.py
@@ -249,5 +249,10 @@ class Settings:
             models.append(self.SIMPLE_MODEL)
         return models
 
+    @property
+    def AGENT_ROLE_DETECTION(self) -> bool:
+        """Enable agent role detection for coding agents (opt-in)."""
+        return os.getenv("NADIRCLAW_AGENT_ROLE_DETECTION", "false").lower() in ("true", "1", "yes")
+
 
 settings = Settings()

--- a/tests/test_agent_role.py
+++ b/tests/test_agent_role.py
@@ -1,0 +1,182 @@
+"""Tests for agent role detection and plan mode routing."""
+
+import pytest
+
+from nadirclaw.routing import (
+    detect_agent_role,
+    _get_last_assistant_tool_calls,
+    _route_planning_session,
+)
+
+
+class TestDetectAgentRole:
+    """Tests for detect_agent_role()."""
+
+    def test_planning_markers(self):
+        result = detect_agent_role("You are a software architect agent for planning")
+        assert result["role"] == "planning"
+        assert result["confidence"] == 0.95
+
+    def test_plan_mode_active(self):
+        result = detect_agent_role("Plan mode is active. Read-only planning specialist.")
+        assert result["role"] == "planning"
+
+    def test_explore_markers(self):
+        result = detect_agent_role("Fast agent specialized for exploring codebases")
+        assert result["role"] == "explore"
+        assert result["confidence"] == 0.95
+
+    def test_subagent_markers(self):
+        result = detect_agent_role("You are a specialized agent for code review")
+        assert result["role"] == "subagent"
+        assert result["confidence"] == 0.90
+
+    def test_background_agent(self):
+        result = detect_agent_role("Background agent for search tasks")
+        assert result["role"] == "subagent"
+
+    def test_main_session_not_subagent(self):
+        # Long system prompt should NOT be classified as subagent
+        long_prompt = "You are Claude Code. " * 2000  # > 15000 chars
+        result = detect_agent_role(long_prompt)
+        assert result["role"] == "unknown"
+
+    def test_short_system_prompt_subagent(self):
+        short_prompt = "Help the user"  # < 5000 chars, no markers
+        result = detect_agent_role(short_prompt)
+        assert result["role"] == "subagent"
+        assert result["confidence"] == 0.50
+
+    def test_unknown_role(self):
+        medium_prompt = "You are a helpful assistant" * 300  # ~8K chars
+        result = detect_agent_role(medium_prompt)
+        assert result["role"] == "unknown"
+
+
+class TestGetLastAssistantToolCalls:
+    """Tests for _get_last_assistant_tool_calls()."""
+
+    def test_no_assistant_messages(self):
+        msgs = [
+            _msg("user", "hello"),
+            _msg("tool", "result"),
+        ]
+        assert _get_last_assistant_tool_calls(msgs) == []
+
+    def test_assistant_with_tool_calls(self):
+        msgs = [
+            _msg("user", "read the file"),
+            _assistant_with_tools(["Read", "Bash"]),
+            _msg("tool", "file contents"),
+        ]
+        assert _get_last_assistant_tool_calls(msgs) == ["Read", "Bash"]
+
+    def test_returns_last_assistant_only(self):
+        msgs = [
+            _assistant_with_tools(["Grep"]),
+            _msg("tool", "results"),
+            _assistant_with_tools(["Read", "Edit"]),
+            _msg("tool", "output"),
+        ]
+        assert _get_last_assistant_tool_calls(msgs) == ["Read", "Edit"]
+
+
+class TestRoutePlanningSession:
+    """Tests for _route_planning_session()."""
+
+    def test_user_initiated_routes_to_reasoning(self):
+        routing_info = {"modifiers_applied": []}
+        msgs = [_msg("user", "/plan create deployment")]
+        _route_planning_session(
+            msgs, "simple-model", "simple",
+            "simple-model", "complex-model", "reasoning-model",
+            "subagent-model", "free-model", routing_info,
+        )
+        assert routing_info["final_model"] == "reasoning-model"
+        assert routing_info["final_tier"] == "reasoning"
+
+    def test_exploration_routes_to_fast(self):
+        routing_info = {"modifiers_applied": []}
+        msgs = [
+            _assistant_with_tools(["Read", "Glob"]),
+            _msg("tool", "file contents"),
+        ]
+        _route_planning_session(
+            msgs, "simple-model", "simple",
+            "simple-model", "complex-model", "reasoning-model",
+            "subagent-model", "free-model", routing_info,
+        )
+        assert routing_info["final_model"] == "subagent-model"
+        assert routing_info["final_tier"] == "subagent"
+
+    def test_plan_generation_routes_to_reasoning(self):
+        routing_info = {"modifiers_applied": []}
+        msgs = [
+            _assistant_with_tools(["Write", "Edit"]),
+            _msg("tool", "file written"),
+        ]
+        _route_planning_session(
+            msgs, "simple-model", "simple",
+            "simple-model", "complex-model", "reasoning-model",
+            "subagent-model", "free-model", routing_info,
+        )
+        assert routing_info["final_model"] == "reasoning-model"
+        assert routing_info["final_tier"] == "reasoning"
+
+    def test_context_default_routes_to_fast(self):
+        routing_info = {"modifiers_applied": []}
+        msgs = [
+            _msg("user", "hello"),
+            _msg("tool", "some result without clear tool call"),
+        ]
+        _route_planning_session(
+            msgs, "simple-model", "simple",
+            "simple-model", "complex-model", "reasoning-model",
+            "subagent-model", "free-model", routing_info,
+        )
+        assert routing_info["final_model"] == "subagent-model"
+        assert routing_info["final_tier"] == "subagent"
+
+    def test_no_reasoning_model_falls_back_to_complex(self):
+        routing_info = {"modifiers_applied": []}
+        msgs = [_msg("user", "/plan something")]
+        _route_planning_session(
+            msgs, "simple-model", "simple",
+            "simple-model", "complex-model", None,
+            "subagent-model", "free-model", routing_info,
+        )
+        assert routing_info["final_model"] == "complex-model"
+
+    def test_no_subagent_model_falls_back_to_simple(self):
+        routing_info = {"modifiers_applied": []}
+        msgs = [
+            _assistant_with_tools(["Bash"]),
+            _msg("tool", "output"),
+        ]
+        _route_planning_session(
+            msgs, "simple-model", "simple",
+            "simple-model", "complex-model", "reasoning-model",
+            None, None, routing_info,
+        )
+        assert routing_info["final_model"] == "simple-model"
+
+
+# --- Test helpers ---
+
+class _msg:
+    """Simple message stub for testing."""
+    def __init__(self, role: str, content: str):
+        self.role = role
+        self.content = content
+        self.text_content = lambda: content
+
+
+class _assistant_with_tools:
+    """Assistant message stub with tool_use blocks."""
+    def __init__(self, tool_names: list[str]):
+        self.role = "assistant"
+        self.content = [
+            {"type": "tool_use", "name": name, "id": f"call_{i}"}
+            for i, name in enumerate(tool_names)
+        ]
+        self.text_content = lambda: ""

--- a/tests/test_agent_role.py
+++ b/tests/test_agent_role.py
@@ -45,7 +45,7 @@ class TestDetectAgentRole:
         short_prompt = "Help the user"  # < 5000 chars, no markers
         result = detect_agent_role(short_prompt)
         assert result["role"] == "subagent"
-        assert result["confidence"] == 0.50
+        assert result["confidence"] == 0.60
 
     def test_unknown_role(self):
         medium_prompt = "You are a helpful assistant" * 300  # ~8K chars


### PR DESCRIPTION
## Summary

- Add **agent role detection** — identify AI coding assistant session types (planning, explore, subagent) from system prompt markers
- **Phase-aware planning mode routing** — route differently based on the current planning phase:
  - **USER** (new request, no tool result) → reasoning model for decision-making
  - **EXPLORATION** (Read/Glob/Grep results) → fast model for speed
  - **PLAN_GENERATION** (Write/Edit tools) → reasoning model for quality
  - **CONTEXT** (indeterminate) → fast model as default
- **Explore agent** detection → routes to configurable `explore_model`
- **Subagent** detection → routes to configurable `subagent_model`
- Main session protection (>15KB system prompt) prevents misclassification

## New API

```python
# routing.py — new function
detect_agent_role(system_prompt, message_count, tool_names) -> {"role": str, "confidence": float, "signals": list}

# apply_routing_modifiers — new optional params
explore_model: Optional[str] = None
subagent_model: Optional[str] = None
```

## Motivation

When using NadirClaw as a proxy for AI coding assistants (Claude Code, Cursor, etc.), the system prompt contains markers that reveal the session type. Planning sessions should route differently based on the current phase — exploration can use fast/cheap models, while plan generation needs the best reasoning model. This provides significant cost savings without sacrificing quality.

## Testing

- 17 new unit tests: role detection, tool call extraction, planning phase routing
- All 79 existing routing tests still pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)