### PR TITLE
feat: show model success rate on dashboard cards

### DIFF
--- a/nadirclaw/web_dashboard.py
+++ b/nadirclaw/web_dashboard.py
@@ -39,6 +39,47 @@ def _load_recent_logs(limit: int = 200) -> List[Dict[str, Any]]:
     return entries
 
 
+# Reason bucketing matches on error_type class names for stable classification.
+# Schema: fallback_reasons entries are {"model", "error_type", "message"} (PR #47).
+_REASON_BUCKETS: Dict[str, set] = {
+    "rate_limit": {"RateLimitExhausted", "RateLimitError"},
+    "timeout": {"ReadTimeout", "ConnectTimeout", "Timeout", "TimeoutError"},
+    "connection_error": {"ConnectError", "APIConnectionError"},
+    "disconnected": {"RemoteProtocolError", "EndOfStream"},
+}
+
+
+def _classify_error_type(error_type: str) -> str:
+    """Map an error_type class name to a dashboard reason bucket."""
+    for bucket, names in _REASON_BUCKETS.items():
+        if error_type in names:
+            return bucket
+    if error_type.endswith("ServerError"):
+        return "server_error"
+    return "other"
+
+
+def compute_model_stats(completions: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """Aggregate per-model success/fail counts and categorized reasons.
+
+    Success = request landed on `selected_model`. Fail = every entry in
+    `fallback_reasons`, attributed to the model that actually failed.
+    """
+    stats: Dict[str, Dict[str, Any]] = {}
+    for e in completions:
+        model = e.get("selected_model", "unknown")
+        stats.setdefault(model, {"success": 0, "fail": 0, "fail_reasons": {}})
+        stats[model]["success"] += 1
+        for fr in e.get("fallback_reasons") or []:
+            fm = fr.get("model", "unknown")
+            stats.setdefault(fm, {"success": 0, "fail": 0, "fail_reasons": {}})
+            stats[fm]["fail"] += 1
+            bucket = _classify_error_type(fr.get("error_type", ""))
+            reasons = stats[fm]["fail_reasons"]
+            reasons[bucket] = reasons.get(bucket, 0) + 1
+    return stats
+
+
 @router.get("/dashboard/api/stats")
 async def dashboard_stats(
     current_user: UserSession = Depends(validate_local_auth),
@@ -97,31 +138,8 @@ async def dashboard_stats(
     # Fallback stats
     fallbacks = sum(1 for e in completions if e.get("fallback_used"))
 
-    # Model success/failure tracking from fallback_reasons
-    model_stats: Dict[str, Dict[str, Any]] = {}
-    for e in completions:
-        # Count successful request
-        model = e.get("selected_model", "unknown")
-        if model not in model_stats:
-            model_stats[model] = {"success": 0, "fail": 0, "fail_reasons": {}}
-        model_stats[model]["success"] += 1
-        # Count failed attempts from fallback_reasons
-        for fr in e.get("fallback_reasons") or []:
-            fm = fr.get("model", "unknown")
-            if fm not in model_stats:
-                model_stats[fm] = {"success": 0, "fail": 0, "fail_reasons": {}}
-            model_stats[fm]["fail"] += 1
-            reason_raw = fr.get("reason", "")
-            reason_type = "other"
-            if "rate" in reason_raw.lower() and "limit" in reason_raw.lower():
-                reason_type = "rate_limit"
-            elif "disconnect" in reason_raw.lower() or "endofstream" in reason_raw.lower():
-                reason_type = "disconnected"
-            elif "connection" in reason_raw.lower() or "connecterror" in reason_raw.lower():
-                reason_type = "connection_error"
-            elif "timeout" in reason_raw.lower():
-                reason_type = "timeout"
-            model_stats[fm]["fail_reasons"][reason_type] = model_stats[fm]["fail_reasons"].get(reason_type, 0) + 1
+    # Model success/failure tracking from fallback_reasons (schema: PR #47).
+    model_stats = compute_model_stats(completions)
 
     # Optimization stats
     total_tokens_saved = sum(e.get("tokens_saved", 0) or 0 for e in completions)

--- a/nadirclaw/web_dashboard.py
+++ b/nadirclaw/web_dashboard.py
@@ -97,6 +97,32 @@ async def dashboard_stats(
     # Fallback stats
     fallbacks = sum(1 for e in completions if e.get("fallback_used"))
 
+    # Model success/failure tracking from fallback_reasons
+    model_stats: Dict[str, Dict[str, Any]] = {}
+    for e in completions:
+        # Count successful request
+        model = e.get("selected_model", "unknown")
+        if model not in model_stats:
+            model_stats[model] = {"success": 0, "fail": 0, "fail_reasons": {}}
+        model_stats[model]["success"] += 1
+        # Count failed attempts from fallback_reasons
+        for fr in e.get("fallback_reasons") or []:
+            fm = fr.get("model", "unknown")
+            if fm not in model_stats:
+                model_stats[fm] = {"success": 0, "fail": 0, "fail_reasons": {}}
+            model_stats[fm]["fail"] += 1
+            reason_raw = fr.get("reason", "")
+            reason_type = "other"
+            if "rate" in reason_raw.lower() and "limit" in reason_raw.lower():
+                reason_type = "rate_limit"
+            elif "disconnect" in reason_raw.lower() or "endofstream" in reason_raw.lower():
+                reason_type = "disconnected"
+            elif "connection" in reason_raw.lower() or "connecterror" in reason_raw.lower():
+                reason_type = "connection_error"
+            elif "timeout" in reason_raw.lower():
+                reason_type = "timeout"
+            model_stats[fm]["fail_reasons"][reason_type] = model_stats[fm]["fail_reasons"].get(reason_type, 0) + 1
+
     # Optimization stats
     total_tokens_saved = sum(e.get("tokens_saved", 0) or 0 for e in completions)
     total_original_tokens = sum(e.get("original_tokens", 0) or 0 for e in completions if e.get("original_tokens"))
@@ -117,6 +143,7 @@ async def dashboard_stats(
             "savings_pct": round(opt_savings_pct, 1),
             "optimized_requests": optimized_requests,
         },
+        "model_stats": model_stats,
     }
 
 
@@ -246,16 +273,29 @@ async function refresh() {
       legend.innerHTML += '<span style="color:' + (TIER_COLORS[tier]||'#4b5563') + '">' + tier + ' ' + count + ' (' + pct.toFixed(0) + '%)</span>  ';
     }
 
-    // Model cards
+    // Model cards (with success rate from model_stats)
+    const ms = d.model_stats || {};
     const mg = document.getElementById('model-grid');
     mg.innerHTML = '';
     for (const [name, info] of Object.entries(d.model_usage)) {
-      mg.innerHTML += '<div class="model-card"><div class="model-name">' + name + '</div><div class="model-stats">' +
-        '<div>Requests <span>' + info.requests + '</span></div>' +
-        '<div>Tokens <span>' + info.tokens.toLocaleString() + '</span></div>' +
+      const msEntry = ms[name];
+      const success = msEntry ? msEntry.success : info.requests;
+      const fail = msEntry ? msEntry.fail : 0;
+      const total = success + fail;
+      const rate = total > 0 ? (success / total * 100) : 100;
+      const rateColor = rate >= 95 ? '#34d399' : rate >= 80 ? '#fbbf24' : '#ef4444';
+      let card = '<div class="model-card"><div class="model-name">' + name + '</div><div class="model-stats">' +
+        '<div>Requests <span>' + info.requests + '</span></div>';
+      if (fail > 0) {
+        card += '<div>Success <span style="color:' + rateColor + '">' + success + '/' + total + ' (' + rate.toFixed(0) + '%)</span></div>';
+        const reasons = Object.entries(msEntry.fail_reasons || {}).map(([r,c]) => r+':'+c).join(', ');
+        if (reasons) card += '<div style="color:#6b7280;font-size:0.7rem;grid-column:span 2">' + reasons + '</div>';
+      }
+      card += '<div>Tokens <span>' + info.tokens.toLocaleString() + '</span></div>' +
         '<div>Cost <span>$' + info.cost.toFixed(4) + '</span></div>' +
         '<div>Avg latency <span>' + info.avg_latency_ms + 'ms</span></div>' +
         '</div></div>';
+      mg.innerHTML += card;
     }
 
     // Recent

--- a/tests/test_web_dashboard.py
+++ b/tests/test_web_dashboard.py
@@ -1,0 +1,126 @@
+"""Tests for web_dashboard model_stats aggregation."""
+
+from nadirclaw.web_dashboard import compute_model_stats, _classify_error_type
+
+
+def _completion(selected_model: str, fallback_reasons=None, **extra):
+    """Build a synthetic completion log entry."""
+    entry = {
+        "type": "completion",
+        "status": "ok",
+        "selected_model": selected_model,
+        "tier": "complex",
+        "fallback_reasons": fallback_reasons or [],
+    }
+    entry.update(extra)
+    return entry
+
+
+class TestClassifyErrorType:
+    def test_rate_limit_class_names(self):
+        assert _classify_error_type("RateLimitExhausted") == "rate_limit"
+        assert _classify_error_type("RateLimitError") == "rate_limit"
+
+    def test_timeout_class_names(self):
+        assert _classify_error_type("ReadTimeout") == "timeout"
+        assert _classify_error_type("ConnectTimeout") == "timeout"
+        assert _classify_error_type("Timeout") == "timeout"
+        assert _classify_error_type("TimeoutError") == "timeout"
+
+    def test_connection_class_names(self):
+        assert _classify_error_type("ConnectError") == "connection_error"
+        assert _classify_error_type("APIConnectionError") == "connection_error"
+
+    def test_disconnected_class_names(self):
+        assert _classify_error_type("RemoteProtocolError") == "disconnected"
+        assert _classify_error_type("EndOfStream") == "disconnected"
+
+    def test_server_error_suffix(self):
+        assert _classify_error_type("InternalServerError") == "server_error"
+        assert _classify_error_type("ServiceUnavailableServerError") == "server_error"
+
+    def test_unknown_falls_through(self):
+        assert _classify_error_type("") == "other"
+        assert _classify_error_type("SomeRandomThing") == "other"
+
+    def test_no_substring_false_positives(self):
+        # Previous substring-match logic classified anything containing
+        # "connection" as connection_error — including words like
+        # "ConnectionPoolTimeoutError" which is really a timeout. We only
+        # match on exact class names now, so unknown-but-connection-shaped
+        # names fall through to "other" rather than being miscategorised.
+        assert _classify_error_type("ConnectionPoolTimeoutError") == "other"
+
+
+class TestComputeModelStats:
+    def test_single_success(self):
+        stats = compute_model_stats([_completion("m1")])
+        assert stats == {"m1": {"success": 1, "fail": 0, "fail_reasons": {}}}
+
+    def test_single_fallback_reason(self):
+        entry = _completion(
+            "m2",
+            fallback_reasons=[{"model": "m1", "error_type": "RateLimitExhausted", "message": "429"}],
+        )
+        stats = compute_model_stats([entry])
+        assert stats["m1"]["fail"] == 1
+        assert stats["m1"]["success"] == 0
+        assert stats["m1"]["fail_reasons"] == {"rate_limit": 1}
+        # m2 succeeded after fallback
+        assert stats["m2"]["success"] == 1
+        assert stats["m2"]["fail"] == 0
+
+    def test_multiple_reasons_bucketed(self):
+        entries = [
+            _completion("m3", fallback_reasons=[
+                {"model": "m1", "error_type": "RateLimitExhausted", "message": "x"},
+                {"model": "m2", "error_type": "ReadTimeout", "message": "y"},
+            ]),
+            _completion("m3", fallback_reasons=[
+                {"model": "m1", "error_type": "ConnectError", "message": "z"},
+            ]),
+        ]
+        stats = compute_model_stats(entries)
+        assert stats["m1"]["fail"] == 2
+        assert stats["m1"]["fail_reasons"] == {"rate_limit": 1, "connection_error": 1}
+        assert stats["m2"]["fail"] == 1
+        assert stats["m2"]["fail_reasons"] == {"timeout": 1}
+        assert stats["m3"]["success"] == 2
+
+    def test_unknown_error_type_lands_in_other(self):
+        entry = _completion(
+            "m2",
+            fallback_reasons=[{"model": "m1", "error_type": "MysteryError", "message": "?"}],
+        )
+        stats = compute_model_stats([entry])
+        assert stats["m1"]["fail_reasons"] == {"other": 1}
+
+    def test_missing_error_type_is_other(self):
+        # Backward compat: older logs may omit error_type entirely.
+        entry = _completion(
+            "m2",
+            fallback_reasons=[{"model": "m1"}],
+        )
+        stats = compute_model_stats([entry])
+        assert stats["m1"]["fail_reasons"] == {"other": 1}
+
+    def test_no_fallback_reasons_key(self):
+        # Ensure None/missing fallback_reasons doesn't explode.
+        entry = {"type": "completion", "status": "ok", "selected_model": "m1"}
+        stats = compute_model_stats([entry])
+        assert stats == {"m1": {"success": 1, "fail": 0, "fail_reasons": {}}}
+
+    def test_success_rate_scenario_from_review(self):
+        """Reviewer's scenario: 50 requests, 2 failed on primary m1 then
+        succeeded on m2. Expect m1: 48 success, 2 fail; m2: 2 success, 0 fail."""
+        entries = []
+        for _ in range(48):
+            entries.append(_completion("m1"))
+        for _ in range(2):
+            entries.append(_completion(
+                "m2",
+                fallback_reasons=[{"model": "m1", "error_type": "RateLimitExhausted", "message": "429"}],
+            ))
+        stats = compute_model_stats(entries)
+        assert stats["m1"] == {"success": 48, "fail": 2, "fail_reasons": {"rate_limit": 2}}
+        assert stats["m2"] == {"success": 2, "fail": 0, "fail_reasons": {}}


### PR DESCRIPTION
## Summary

Adds per-model success/failure rate tracking and display on the dashboard's model cards.

When models have failures (tracked via `fallback_reasons` in `requests.jsonl`), the model card now shows:
- Success count / total attempts (e.g. `48/50 (96%)`)
- Color coding: green (≥95%), yellow (≥80%), red (<80%)
- Categorized failure reasons: `rate_limit`, `disconnected`, `connection_error`, `timeout`, `other`

Models with no failures display unchanged — no noise for healthy models.

## Changes

- **`web_dashboard.py`**: Added `model_stats` to `/dashboard/api/stats` response — scans `fallback_reasons` to count per-model success/fail with reason classification. Updated model card rendering to show success rate when failures exist.

## Screenshot

Model cards now look like:
```
claude-sonnet-4-6
Requests  254
Success   232/254 (91%)
rate_limit:18, disconnected:4
Tokens    125,432
Cost      $1.2345
Avg latency 3200ms
```

## Test plan

- [ ] Run NadirClaw with multiple models and some fallbacks occurring
- [ ] Open `/dashboard` and verify model cards show success rate only for models with failures
- [ ] Verify models with 0 failures still show the original card layout
- [ ] Check color coding matches thresholds (green ≥95%, yellow ≥80%, red <80%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)