### PR TITLE
add update-models metadata refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to NadirClaw will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **`nadirclaw update-models` command** — writes refreshable model metadata to `~/.nadirclaw/models.json`, optionally merging a published registry JSON via `--source-url` or `NADIRCLAW_MODEL_REGISTRY_URL`.
+- **Local model metadata overrides** — the router now merges `~/.nadirclaw/models.json` and user-managed `~/.nadirclaw/models.local.json` into the runtime model registry.
+- **DeepSeek V4 explicit aliases** — added `deepseek-v4`, `deepseek-v4-flash`, and `deepseek-v4-pro` while preserving the existing `deepseek` alias for `deepseek/deepseek-chat`.
+
 ## [0.14.0] - 2026-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ Use short names instead of full model IDs:
 | `gpt5` | `gpt-5.2` |
 | `flash` | `gemini-2.5-flash` |
 | `gemini-pro` | `gemini-2.5-pro` |
-| `deepseek` | `deepseek/deepseek-v4-flash` |
+| `deepseek` | `deepseek/deepseek-chat` |
 | `deepseek-v4` | `deepseek/deepseek-v4-flash` |
 | `deepseek-v4-flash` | `deepseek/deepseek-v4-flash` |
 | `deepseek-v4-pro` | `deepseek/deepseek-v4-pro` |
@@ -740,6 +740,9 @@ Without options it exports the built-in registry. Pass `--source-url` or set
 `NADIRCLAW_MODEL_REGISTRY_URL` to merge a published registry JSON before saving. The
 router merges the saved file at startup, then applies any user-managed overrides from
 `~/.nadirclaw/models.local.json`.
+
+`update-models` only rewrites the generated metadata file. It does not re-export
+entries from `models.local.json`, so local overrides stay separate across refreshes.
 
 Use `models.local.json` for private models or custom pricing:
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ NADIRCLAW_FALLBACK_CHAIN=gpt-4.1,claude-sonnet-4-5-20250929,gemini-2.5-flash  # 
 | **Claude + Claude** | `claude-haiku-4-5-20251001` | `claude-sonnet-4-5-20250929` | `ANTHROPIC_API_KEY` |
 | **OpenAI + Ollama** | `ollama/llama3.1:8b` | `gpt-4.1` | `OPENAI_API_KEY` |
 | **OpenAI + OpenAI** | `gpt-4.1-mini` | `gpt-4.1` | `OPENAI_API_KEY` |
+| **DeepSeek + DeepSeek** | `deepseek/deepseek-v4-flash` | `deepseek/deepseek-v4-pro` | `DEEPSEEK_API_KEY` |
 | **OpenAI Codex** | `gemini-2.5-flash` | `openai-codex/gpt-5.3-codex` | `GEMINI_API_KEY` + OAuth login |
 | **Fully local** | `ollama/llama3.1:8b` | `ollama/qwen3:32b` | None |
 
@@ -634,7 +635,10 @@ Use short names instead of full model IDs:
 | `gpt5` | `gpt-5.2` |
 | `flash` | `gemini-2.5-flash` |
 | `gemini-pro` | `gemini-2.5-pro` |
-| `deepseek` | `deepseek/deepseek-chat` |
+| `deepseek` | `deepseek/deepseek-v4-flash` |
+| `deepseek-v4` | `deepseek/deepseek-v4-flash` |
+| `deepseek-v4-flash` | `deepseek/deepseek-v4-flash` |
+| `deepseek-v4-pro` | `deepseek/deepseek-v4-pro` |
 | `deepseek-r1` | `deepseek/deepseek-reasoner` |
 | `llama` | `ollama/llama3.1:8b` |
 
@@ -693,6 +697,7 @@ If the estimated token count of a request exceeds a model's context window, Nadi
 nadirclaw setup              # Interactive setup wizard (providers, keys, models)
 nadirclaw serve              # Start the router server
 nadirclaw serve --log-raw    # Start with full request/response logging
+nadirclaw update-models      # Refresh local model metadata
 nadirclaw test               # Probe each configured model and verify it responds
 nadirclaw optimize <file>    # Test context compaction on a file (dry-run)
 nadirclaw classify <prompt>  # Classify a prompt (no server needed)
@@ -726,6 +731,29 @@ nadirclaw openwebui onboard  # Show Open WebUI setup instructions
 nadirclaw continue onboard   # Configure Continue (continue.dev) integration
 nadirclaw cursor onboard     # Show Cursor editor setup instructions
 nadirclaw build-centroids    # Regenerate centroid vectors from prototypes
+```
+
+### Model Metadata Updates
+
+`nadirclaw update-models` writes model metadata to `~/.nadirclaw/models.json`.
+Without options it exports the built-in registry. Pass `--source-url` or set
+`NADIRCLAW_MODEL_REGISTRY_URL` to merge a published registry JSON before saving. The
+router merges the saved file at startup, then applies any user-managed overrides from
+`~/.nadirclaw/models.local.json`.
+
+Use `models.local.json` for private models or custom pricing:
+
+```json
+{
+  "models": {
+    "openai/my-local-model": {
+      "context_window": 32768,
+      "cost_per_m_input": 0,
+      "cost_per_m_output": 0,
+      "has_vision": false
+    }
+  }
+}
 ```
 
 ### `nadirclaw serve`
@@ -1112,6 +1140,9 @@ Auth is disabled by default (local-only). Set `NADIRCLAW_AUTH_TOKEN` to require 
 | `NADIRCLAW_BUDGET_STDOUT_ALERTS` | `false` | Print alerts to stdout (`true`/`1`/`yes` to enable) |
 | `NADIRCLAW_MODEL_RATE_LIMITS` | *(none)* | Per-model RPM limits, e.g. `gemini-3-flash-preview=30,gpt-4.1=60` |
 | `NADIRCLAW_DEFAULT_MODEL_RPM` | `0` (unlimited) | Default max requests/minute for any model not in `MODEL_RATE_LIMITS` |
+| `NADIRCLAW_MODEL_REGISTRY_URL` | *(empty — disabled)* | Optional registry JSON URL for `nadirclaw update-models` |
+| `NADIRCLAW_MODEL_METADATA_FILE` | `~/.nadirclaw/models.json` | Generated model metadata file loaded at startup |
+| `NADIRCLAW_LOCAL_MODEL_METADATA_FILE` | `~/.nadirclaw/models.local.json` | User-managed model metadata overrides loaded after generated metadata |
 | `NADIRCLAW_AUTH_TOKEN` | *(empty — auth disabled)* | Set to require a bearer token |
 | `GEMINI_API_KEY` | -- | Google Gemini API key (also accepts `GOOGLE_API_KEY`) |
 | `ANTHROPIC_API_KEY` | -- | Anthropic API key |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,8 +15,8 @@ has already shipped.
 - [ ] **Provider health-aware routing** — track rolling error rates per provider (429 / 5xx /
       timeout) and downgrade to the next healthy option automatically; expose health scores in
       `nadirclaw status`
-- [ ] **`nadirclaw update-models` command** — pull the latest model list, context windows, and
-      pricing from a published registry JSON; removes the need for manual constant updates
+- [x] **`nadirclaw update-models` command** — writes local model metadata to
+      `~/.nadirclaw/models.json`, with `models.local.json` support for user overrides
 
 ---
 

--- a/nadirclaw/cli.py
+++ b/nadirclaw/cli.py
@@ -243,6 +243,7 @@ def status():
               help="Output format")
 def update_models(output, source_url, dry_run, fmt):
     """Refresh local model metadata used by the router."""
+    import urllib.error
     import urllib.request
 
     from nadirclaw.model_metadata import (
@@ -258,12 +259,18 @@ def update_models(output, source_url, dry_run, fmt):
         model: dict(info)
         for model, info in sorted(BUILTIN_MODEL_REGISTRY.items())
     }
-    source = source_url or os.getenv("NADIRCLAW_MODEL_REGISTRY_URL", "")
+    env_source = os.getenv("NADIRCLAW_MODEL_REGISTRY_URL", "")
+    if env_source and not env_source.startswith(("http://", "https://")):
+        raise click.ClickException(f"Source URL must use http(s): {env_source}")
+    source = source_url or env_source
 
     if source:
-        with urllib.request.urlopen(source, timeout=15) as resp:
-            remote_payload = json.loads(resp.read())
-        remote_models = parse_model_metadata(remote_payload)
+        try:
+            with urllib.request.urlopen(source, timeout=15) as resp:
+                remote_payload = json.loads(resp.read())
+            remote_models = parse_model_metadata(remote_payload)
+        except (OSError, ValueError, urllib.error.URLError) as e:
+            raise click.ClickException(str(e)) from e
         for model, info in remote_models.items():
             models[model] = {**models.get(model, {}), **info}
 

--- a/nadirclaw/cli.py
+++ b/nadirclaw/cli.py
@@ -233,6 +233,68 @@ def status():
         click.echo("\nServer:        NOT RUNNING")
 
 
+@main.command("update-models")
+@click.option("--output", type=click.Path(path_type=Path), default=None,
+              help="Metadata file to write (default: ~/.nadirclaw/models.json)")
+@click.option("--source-url", default=None,
+              help="Optional registry JSON URL to merge before writing")
+@click.option("--dry-run", is_flag=True, help="Show what would be written without saving")
+@click.option("--format", "fmt", default="text", type=click.Choice(["text", "json"]),
+              help="Output format")
+def update_models(output, source_url, dry_run, fmt):
+    """Refresh local model metadata used by the router."""
+    import urllib.request
+
+    from nadirclaw.model_metadata import (
+        default_metadata_path,
+        local_metadata_path,
+        parse_model_metadata,
+        write_model_metadata,
+    )
+    from nadirclaw.routing import BUILTIN_MODEL_REGISTRY
+
+    output_path = output or default_metadata_path()
+    models = {
+        model: dict(info)
+        for model, info in sorted(BUILTIN_MODEL_REGISTRY.items())
+    }
+    source = source_url or os.getenv("NADIRCLAW_MODEL_REGISTRY_URL", "")
+
+    if source:
+        with urllib.request.urlopen(source, timeout=15) as resp:
+            remote_payload = json.loads(resp.read())
+        remote_models = parse_model_metadata(remote_payload)
+        for model, info in remote_models.items():
+            models[model] = {**models.get(model, {}), **info}
+
+    if not dry_run:
+        write_model_metadata(models, output_path, source=source or "builtin")
+
+    result = {
+        "path": str(output_path),
+        "local_override_path": str(local_metadata_path()),
+        "model_count": len(models),
+        "dry_run": dry_run,
+        "source": source or "builtin",
+        "models": list(models.keys()),
+    }
+
+    if fmt == "json":
+        click.echo(json.dumps(result, indent=2))
+        return
+
+    action = "Would write" if dry_run else "Updated"
+    plural = "entry" if len(models) == 1 else "entries"
+    click.echo(f"{action} {len(models)} model metadata {plural}")
+    click.echo(f"Path: {output_path}")
+    click.echo(f"Source: {source or 'builtin'}")
+    click.echo(f"Local overrides: {local_metadata_path()}")
+    if models:
+        click.echo("Sample models:")
+        for model in list(models.keys())[:5]:
+            click.echo(f"  - {model}")
+
+
 @main.command()
 @click.option("--since", default=None, help="Time filter: '24h', '7d', '2025-02-01'")
 @click.option("--model", default=None, help="Filter by model name (substring match)")

--- a/nadirclaw/model_metadata.py
+++ b/nadirclaw/model_metadata.py
@@ -54,8 +54,33 @@ def parse_model_metadata(data: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
             continue
         if not isinstance(info, dict):
             raise ValueError(f"metadata for {model_id!r} must be a JSON object")
-        normalized[model_id.strip()] = dict(info)
+        normalized[model_id.strip()] = _validate_model_info(model_id.strip(), info)
     return normalized
+
+
+def _validate_model_info(model_id: str, info: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate known metadata fields while preserving unknown fields."""
+    normalized = dict(info)
+    if "context_window" in normalized:
+        value = normalized["context_window"]
+        if type(value) is not int or value < 0:
+            raise ValueError(f"{model_id}.context_window must be a non-negative integer")
+
+    for key in ("cost_per_m_input", "cost_per_m_output"):
+        if key not in normalized:
+            continue
+        value = normalized[key]
+        if not _is_non_negative_number(value):
+            raise ValueError(f"{model_id}.{key} must be a non-negative number")
+
+    if "has_vision" in normalized and type(normalized["has_vision"]) is not bool:
+        raise ValueError(f"{model_id}.has_vision must be a boolean")
+
+    return normalized
+
+
+def _is_non_negative_number(value: Any) -> bool:
+    return type(value) in (int, float) and value >= 0
 
 
 def load_model_metadata(path: Path) -> Dict[str, Dict[str, Any]]:
@@ -80,4 +105,6 @@ def write_model_metadata(
         "updated_at": datetime.now(timezone.utc).isoformat(),
         "models": models,
     }
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    os.replace(tmp, path)

--- a/nadirclaw/model_metadata.py
+++ b/nadirclaw/model_metadata.py
@@ -1,0 +1,83 @@
+"""Local model metadata helpers.
+
+Model metadata is stored separately from code so users can refresh or override
+model context windows, pricing, and capabilities without editing routing.py.
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+
+CONFIG_DIR = Path.home() / ".nadirclaw"
+MODEL_METADATA_FILE = "models.json"
+LOCAL_MODEL_METADATA_FILE = "models.local.json"
+
+
+def default_metadata_path() -> Path:
+    """Return the generated model metadata path."""
+    override = os.getenv("NADIRCLAW_MODEL_METADATA_FILE", "")
+    if override:
+        return Path(override).expanduser()
+    return CONFIG_DIR / MODEL_METADATA_FILE
+
+
+def local_metadata_path() -> Path:
+    """Return the user-managed model metadata override path."""
+    override = os.getenv("NADIRCLAW_LOCAL_MODEL_METADATA_FILE", "")
+    if override:
+        return Path(override).expanduser()
+    return CONFIG_DIR / LOCAL_MODEL_METADATA_FILE
+
+
+def metadata_paths() -> Iterable[Path]:
+    """Return metadata files in merge order."""
+    return (default_metadata_path(), local_metadata_path())
+
+
+def _extract_models(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Support both {"models": {...}} and direct {model_id: info} formats."""
+    models = payload.get("models", payload)
+    if not isinstance(models, dict):
+        raise ValueError("model metadata must be a JSON object or contain a 'models' object")
+    return models
+
+
+def parse_model_metadata(data: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Normalize model metadata from a decoded JSON object."""
+    models = _extract_models(data)
+    normalized: Dict[str, Dict[str, Any]] = {}
+    for model_id, info in models.items():
+        if not isinstance(model_id, str) or not model_id.strip():
+            continue
+        if not isinstance(info, dict):
+            raise ValueError(f"metadata for {model_id!r} must be a JSON object")
+        normalized[model_id.strip()] = dict(info)
+    return normalized
+
+
+def load_model_metadata(path: Path) -> Dict[str, Dict[str, Any]]:
+    """Load model metadata from a JSON file."""
+    data = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError("model metadata root must be a JSON object")
+    return parse_model_metadata(data)
+
+
+def write_model_metadata(
+    models: Dict[str, Dict[str, Any]],
+    path: Path,
+    *,
+    source: str = "builtin",
+) -> None:
+    """Write model metadata in the generated file format."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": 1,
+        "source": source,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "models": models,
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")

--- a/nadirclaw/routing.py
+++ b/nadirclaw/routing.py
@@ -207,7 +207,7 @@ MODEL_ALIASES: Dict[str, str] = {
     "flash": "gemini-2.5-flash",
     "gemini-flash": "gemini-2.5-flash",
     "gemini-pro": "gemini-2.5-pro",
-    "deepseek": "deepseek/deepseek-v4-flash",
+    "deepseek": "deepseek/deepseek-chat",
     "deepseek-v4": "deepseek/deepseek-v4-flash",
     "deepseek-v4-flash": "deepseek/deepseek-v4-flash",
     "deepseek-v4-pro": "deepseek/deepseek-v4-pro",

--- a/nadirclaw/routing.py
+++ b/nadirclaw/routing.py
@@ -154,12 +154,38 @@ MODEL_REGISTRY: Dict[str, Dict[str, Any]] = {
     "claude-sonnet-4-20250514": {"context_window": 200_000, "cost_per_m_input": 3.00, "cost_per_m_output": 15.00, "has_vision": True},
     "claude-haiku-4-20250514": {"context_window": 200_000, "cost_per_m_input": 1.00, "cost_per_m_output": 5.00, "has_vision": True},
     # DeepSeek
+    "deepseek/deepseek-v4-flash": {"context_window": 1_000_000, "cost_per_m_input": 0.14, "cost_per_m_output": 0.28, "has_vision": False},
+    "deepseek/deepseek-v4-pro": {"context_window": 1_000_000, "cost_per_m_input": 1.74, "cost_per_m_output": 3.48, "has_vision": False},
     "deepseek/deepseek-chat": {"context_window": 128_000, "cost_per_m_input": 0.28, "cost_per_m_output": 0.42, "has_vision": False},
     "deepseek/deepseek-reasoner": {"context_window": 128_000, "cost_per_m_input": 0.28, "cost_per_m_output": 0.42, "has_vision": False},
     # Ollama (local, no cost, context varies by model)
     "ollama/llama3.1:8b": {"context_window": 128_000, "cost_per_m_input": 0, "cost_per_m_output": 0, "has_vision": False},
     "ollama/qwen3:32b": {"context_window": 128_000, "cost_per_m_input": 0, "cost_per_m_output": 0, "has_vision": False},
 }
+
+BUILTIN_MODEL_REGISTRY: Dict[str, Dict[str, Any]] = {
+    model: dict(info) for model, info in MODEL_REGISTRY.items()
+}
+
+
+def _merge_external_model_metadata() -> None:
+    """Merge generated and user-local model metadata into MODEL_REGISTRY."""
+    from nadirclaw.model_metadata import load_model_metadata, metadata_paths
+
+    for path in metadata_paths():
+        if not path.exists():
+            continue
+        try:
+            models = load_model_metadata(path)
+        except Exception as e:
+            logger.warning("Skipping invalid model metadata file %s: %s", path, e)
+            continue
+        for model_id, info in models.items():
+            current = MODEL_REGISTRY.get(model_id, {})
+            MODEL_REGISTRY[model_id] = {**current, **info}
+
+
+_merge_external_model_metadata()
 
 # ---------------------------------------------------------------------------
 # Model aliases — short names to full model IDs
@@ -181,7 +207,10 @@ MODEL_ALIASES: Dict[str, str] = {
     "flash": "gemini-2.5-flash",
     "gemini-flash": "gemini-2.5-flash",
     "gemini-pro": "gemini-2.5-pro",
-    "deepseek": "deepseek/deepseek-chat",
+    "deepseek": "deepseek/deepseek-v4-flash",
+    "deepseek-v4": "deepseek/deepseek-v4-flash",
+    "deepseek-v4-flash": "deepseek/deepseek-v4-flash",
+    "deepseek-v4-pro": "deepseek/deepseek-v4-pro",
     "deepseek-r1": "deepseek/deepseek-reasoner",
     "llama": "ollama/llama3.1:8b",
 }
@@ -550,14 +579,20 @@ def check_context_window(model: str, messages: List[Any]) -> bool:
     info = MODEL_REGISTRY.get(model)
     if not info:
         return True
+    window = info.get("context_window")
+    if not window:
+        return True
     estimated = estimate_token_count(messages)
-    return estimated < info["context_window"]
+    return estimated < window
 
 
 def get_context_window(model: str) -> Optional[int]:
     """Return context window for a model, or None if unknown."""
     info = MODEL_REGISTRY.get(model)
-    return info["context_window"] if info else None
+    if not info:
+        return None
+    window = info.get("context_window")
+    return int(window) if window else None
 
 
 def has_vision(model: str) -> bool:
@@ -701,8 +736,12 @@ def estimate_cost(model: str, prompt_tokens: int, completion_tokens: int) -> Opt
     info = MODEL_REGISTRY.get(model)
     if not info:
         return None
-    input_cost = (prompt_tokens / 1_000_000) * info["cost_per_m_input"]
-    output_cost = (completion_tokens / 1_000_000) * info["cost_per_m_output"]
+    input_rate = info.get("cost_per_m_input")
+    output_rate = info.get("cost_per_m_output")
+    if input_rate is None or output_rate is None:
+        return None
+    input_cost = (prompt_tokens / 1_000_000) * input_rate
+    output_cost = (completion_tokens / 1_000_000) * output_rate
     return input_cost + output_cost
 
 

--- a/nadirclaw/setup.py
+++ b/nadirclaw/setup.py
@@ -49,7 +49,7 @@ PROVIDER_INFO: Dict[str, Dict] = {
     },
     "deepseek": {
         "display": "DeepSeek",
-        "description": "DeepSeek V3, Reasoner",
+        "description": "DeepSeek V4 Flash, V4 Pro, Reasoner",
         "env_var": "DEEPSEEK_API_KEY",
         "key_prefix": "sk-",
         "oauth": False,
@@ -74,7 +74,7 @@ _TIER_DEFAULTS = {
     "simple": {
         "google": "gemini-2.5-flash",
         "openai": "gpt-4.1-mini",
-        "deepseek": "deepseek/deepseek-chat",
+        "deepseek": "deepseek/deepseek-v4-flash",
         "ollama": "ollama/llama3.1:8b",
         "anthropic": "claude-haiku-4-5-20251001",
     },
@@ -82,12 +82,12 @@ _TIER_DEFAULTS = {
         "anthropic": "claude-sonnet-4-5-20250929",
         "openai": "gpt-4.1",
         "google": "gemini-2.5-pro",
-        "deepseek": "deepseek/deepseek-reasoner",
+        "deepseek": "deepseek/deepseek-v4-pro",
         "ollama": "ollama/qwen3:32b",
     },
     "reasoning": {
         "openai": "o3",
-        "deepseek": "deepseek/deepseek-reasoner",
+        "deepseek": "deepseek/deepseek-v4-pro",
         "anthropic": "claude-sonnet-4-5-20250929",
         "google": "gemini-2.5-pro",
     },

--- a/nadirclaw/setup.py
+++ b/nadirclaw/setup.py
@@ -74,7 +74,7 @@ _TIER_DEFAULTS = {
     "simple": {
         "google": "gemini-2.5-flash",
         "openai": "gpt-4.1-mini",
-        "deepseek": "deepseek/deepseek-v4-flash",
+        "deepseek": "deepseek/deepseek-chat",
         "ollama": "ollama/llama3.1:8b",
         "anthropic": "claude-haiku-4-5-20251001",
     },
@@ -82,12 +82,12 @@ _TIER_DEFAULTS = {
         "anthropic": "claude-sonnet-4-5-20250929",
         "openai": "gpt-4.1",
         "google": "gemini-2.5-pro",
-        "deepseek": "deepseek/deepseek-v4-pro",
+        "deepseek": "deepseek/deepseek-reasoner",
         "ollama": "ollama/qwen3:32b",
     },
     "reasoning": {
         "openai": "o3",
-        "deepseek": "deepseek/deepseek-v4-pro",
+        "deepseek": "deepseek/deepseek-reasoner",
         "anthropic": "claude-sonnet-4-5-20250929",
         "google": "gemini-2.5-pro",
     },

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -95,7 +95,7 @@ class TestResolveAlias:
         assert resolve_alias("unknown-model") is None
 
     def test_deepseek(self):
-        assert resolve_alias("deepseek") == "deepseek/deepseek-v4-flash"
+        assert resolve_alias("deepseek") == "deepseek/deepseek-chat"
         assert resolve_alias("deepseek-v4") == "deepseek/deepseek-v4-flash"
         assert resolve_alias("deepseek-v4-flash") == "deepseek/deepseek-v4-flash"
         assert resolve_alias("deepseek-v4-pro") == "deepseek/deepseek-v4-pro"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,12 +1,15 @@
 """Tests for nadirclaw.routing — routing intelligence."""
 
+import json
 from types import SimpleNamespace
 
 import pytest
 
 from nadirclaw.routing import (
+    MODEL_REGISTRY,
     MODEL_ALIASES,
     SessionCache,
+    _merge_external_model_metadata,
     apply_routing_modifiers,
     check_context_window,
     detect_agentic,
@@ -15,6 +18,7 @@ from nadirclaw.routing import (
     estimate_cost,
     estimate_token_count,
     has_vision,
+    get_context_window,
     resolve_alias,
     resolve_profile,
 )
@@ -91,7 +95,10 @@ class TestResolveAlias:
         assert resolve_alias("unknown-model") is None
 
     def test_deepseek(self):
-        assert resolve_alias("deepseek") == "deepseek/deepseek-chat"
+        assert resolve_alias("deepseek") == "deepseek/deepseek-v4-flash"
+        assert resolve_alias("deepseek-v4") == "deepseek/deepseek-v4-flash"
+        assert resolve_alias("deepseek-v4-flash") == "deepseek/deepseek-v4-flash"
+        assert resolve_alias("deepseek-v4-pro") == "deepseek/deepseek-v4-pro"
         assert resolve_alias("deepseek-r1") == "deepseek/deepseek-reasoner"
 
 
@@ -318,12 +325,45 @@ class TestEstimateCost:
         assert cost is not None
         assert cost > 0
 
+    def test_deepseek_v4_cost(self):
+        cost = estimate_cost("deepseek/deepseek-v4-pro", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(5.22)
+
     def test_unknown_model(self):
         assert estimate_cost("unknown-xyz", 1000, 500) is None
 
     def test_free_model(self):
         cost = estimate_cost("ollama/llama3.1:8b", 1000, 500)
         assert cost == 0.0
+
+
+# ---------------------------------------------------------------------------
+# local model metadata
+# ---------------------------------------------------------------------------
+
+class TestLocalModelMetadata:
+    def test_external_metadata_adds_model(self, tmp_path, monkeypatch):
+        path = tmp_path / "models.json"
+        model = "custom/custom-fast"
+        path.write_text(json.dumps({
+            "models": {
+                model: {
+                    "context_window": 32768,
+                    "cost_per_m_input": 0,
+                    "cost_per_m_output": 0,
+                    "has_vision": False,
+                }
+            }
+        }))
+        monkeypatch.setenv("NADIRCLAW_MODEL_METADATA_FILE", str(path))
+        monkeypatch.setenv("NADIRCLAW_LOCAL_MODEL_METADATA_FILE", str(tmp_path / "missing.json"))
+
+        try:
+            _merge_external_model_metadata()
+            assert get_context_window(model) == 32768
+            assert estimate_cost(model, 1000, 1000) == 0.0
+        finally:
+            MODEL_REGISTRY.pop(model, None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -26,6 +26,7 @@ from nadirclaw.setup import (
     select_default_model,
     write_env_file,
 )
+from nadirclaw.model_metadata import load_model_metadata
 
 
 @pytest.fixture(autouse=True)
@@ -96,6 +97,10 @@ class TestClassifyModelTier:
 
     def test_reasoner_is_reasoning(self):
         assert classify_model_tier("deepseek/deepseek-reasoner") == "reasoning"
+
+    def test_deepseek_v4_tiers(self):
+        assert classify_model_tier("deepseek/deepseek-v4-flash") == "simple"
+        assert classify_model_tier("deepseek/deepseek-v4-pro") == "complex"
 
     def test_ollama_is_free(self):
         assert classify_model_tier("ollama/llama3.1:8b") == "free"
@@ -170,7 +175,12 @@ class TestFilterTopModels:
         assert result == models
 
     def test_deepseek_no_filter(self):
-        models = ["deepseek/deepseek-chat", "deepseek/deepseek-reasoner"]
+        models = [
+            "deepseek/deepseek-chat",
+            "deepseek/deepseek-reasoner",
+            "deepseek/deepseek-v4-flash",
+            "deepseek/deepseek-v4-pro",
+        ]
         result = _filter_top_models("deepseek", models)
         assert result == models
 
@@ -251,6 +261,11 @@ class TestSelectDefaultModel:
     def test_ollama_free(self):
         result = select_default_model("free", ["ollama"])
         assert result == "ollama/llama3.1:8b"
+
+    def test_deepseek_defaults(self):
+        assert select_default_model("simple", ["deepseek"]) == "deepseek/deepseek-v4-flash"
+        assert select_default_model("complex", ["deepseek"]) == "deepseek/deepseek-v4-pro"
+        assert select_default_model("reasoning", ["deepseek"]) == "deepseek/deepseek-v4-pro"
 
     def test_no_matching_provider(self):
         result = select_default_model("simple", ["nonexistent"])
@@ -509,6 +524,56 @@ class TestSetupCLI:
         runner = CliRunner()
         result = runner.invoke(main, ["setup"], input="n\n")
         assert result.exit_code == 0
+
+    def test_update_models_writes_metadata(self, tmp_path):
+        from nadirclaw.cli import main
+
+        output = tmp_path / "models.json"
+        runner = CliRunner()
+        result = runner.invoke(main, ["update-models", "--output", str(output)])
+
+        assert result.exit_code == 0
+        assert output.exists()
+        models = load_model_metadata(output)
+        assert "deepseek/deepseek-v4-pro" in models
+        assert "Updated" in result.output
+
+    def test_update_models_dry_run(self, tmp_path):
+        from nadirclaw.cli import main
+
+        output = tmp_path / "models.json"
+        runner = CliRunner()
+        result = runner.invoke(main, ["update-models", "--output", str(output), "--dry-run"])
+
+        assert result.exit_code == 0
+        assert not output.exists()
+        assert "Would write" in result.output
+
+    def test_update_models_source_url(self, tmp_path):
+        from nadirclaw.cli import main
+
+        source = tmp_path / "source.json"
+        output = tmp_path / "models.json"
+        source.write_text(json.dumps({
+            "models": {
+                "custom/source-model": {
+                    "context_window": 12345,
+                    "cost_per_m_input": 0,
+                    "cost_per_m_output": 0,
+                    "has_vision": False,
+                }
+            }
+        }))
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["update-models", "--output", str(output), "--source-url", source.as_uri()],
+        )
+
+        assert result.exit_code == 0
+        models = load_model_metadata(output)
+        assert models["custom/source-model"]["context_window"] == 12345
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -26,7 +26,7 @@ from nadirclaw.setup import (
     select_default_model,
     write_env_file,
 )
-from nadirclaw.model_metadata import load_model_metadata
+from nadirclaw.model_metadata import load_model_metadata, parse_model_metadata
 
 
 @pytest.fixture(autouse=True)
@@ -263,9 +263,9 @@ class TestSelectDefaultModel:
         assert result == "ollama/llama3.1:8b"
 
     def test_deepseek_defaults(self):
-        assert select_default_model("simple", ["deepseek"]) == "deepseek/deepseek-v4-flash"
-        assert select_default_model("complex", ["deepseek"]) == "deepseek/deepseek-v4-pro"
-        assert select_default_model("reasoning", ["deepseek"]) == "deepseek/deepseek-v4-pro"
+        assert select_default_model("simple", ["deepseek"]) == "deepseek/deepseek-chat"
+        assert select_default_model("complex", ["deepseek"]) == "deepseek/deepseek-reasoner"
+        assert select_default_model("reasoning", ["deepseek"]) == "deepseek/deepseek-reasoner"
 
     def test_no_matching_provider(self):
         result = select_default_model("simple", ["nonexistent"])
@@ -574,6 +574,45 @@ class TestSetupCLI:
         assert result.exit_code == 0
         models = load_model_metadata(output)
         assert models["custom/source-model"]["context_window"] == 12345
+
+    def test_update_models_env_source_requires_http(self, tmp_path, monkeypatch):
+        from nadirclaw.cli import main
+
+        output = tmp_path / "models.json"
+        monkeypatch.setenv("NADIRCLAW_MODEL_REGISTRY_URL", "file:///etc/passwd")
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["update-models", "--output", str(output)])
+
+        assert result.exit_code != 0
+        assert "Source URL must use http(s)" in result.output
+        assert not output.exists()
+
+    def test_update_models_source_failure_is_click_error(self, tmp_path, monkeypatch):
+        import urllib.error
+
+        from nadirclaw.cli import main
+
+        def fail_urlopen(*args, **kwargs):
+            raise urllib.error.URLError("network down")
+
+        monkeypatch.setattr("urllib.request.urlopen", fail_urlopen)
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["update-models", "--output", str(tmp_path / "models.json"), "--source-url", "https://example.test/models.json"],
+        )
+
+        assert result.exit_code != 0
+        assert "network down" in result.output
+
+    def test_model_metadata_rejects_invalid_values(self):
+        with pytest.raises(ValueError, match="context_window"):
+            parse_model_metadata({"models": {"bad/model": {"context_window": "lots"}}})
+        with pytest.raises(ValueError, match="cost_per_m_input"):
+            parse_model_metadata({"models": {"bad/model": {"cost_per_m_input": -5}}})
+        with pytest.raises(ValueError, match="has_vision"):
+            parse_model_metadata({"models": {"bad/model": {"has_vision": "no"}}})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a `nadirclaw update-models` CLI command and local model metadata support so model context windows, pricing, and capabilities can be refreshed or overridden without editing `routing.py`.

## Changes

- Add `nadirclaw update-models` with `--output`, `--dry-run`, `--format json`, and optional `--source-url` / `NADIRCLAW_MODEL_REGISTRY_URL` support.
- Add `nadirclaw/model_metadata.py` for parsing, loading, and writing generated/user model metadata.
- Merge `~/.nadirclaw/models.json` and `~/.nadirclaw/models.local.json` into the runtime model registry.
- Add DeepSeek V4 Flash/Pro registry entries, defaults, aliases, and README examples.
- Document local metadata files and mark the roadmap item complete.

## Validation

- `/opt/anaconda3/bin/python -m pytest tests/test_routing.py tests/test_setup.py` — 147 passed, 1 warning
- `env PYTHONPYCACHEPREFIX=/tmp/nadirclaw-upload-pycache /opt/anaconda3/bin/python -m compileall nadirclaw tests` — passed

## Notes

Full test suite was attempted locally and still has unrelated environment failures around the Anaconda base install: `sentence_transformers/transformers/torch` version mismatch, missing `pytest-asyncio`, and local log directory permissions. The focused routing/setup tests covering this change pass.