### PR TITLE
update-models: enforce http(s) on CLI flag and cap remote payload

### DIFF
--- a/nadirclaw/cli.py
+++ b/nadirclaw/cli.py
@@ -260,14 +260,20 @@ def update_models(output, source_url, dry_run, fmt):
         for model, info in sorted(BUILTIN_MODEL_REGISTRY.items())
     }
     env_source = os.getenv("NADIRCLAW_MODEL_REGISTRY_URL", "")
-    if env_source and not env_source.startswith(("http://", "https://")):
-        raise click.ClickException(f"Source URL must use http(s): {env_source}")
     source = source_url or env_source
+    if source and not source.startswith(("http://", "https://")):
+        raise click.ClickException(f"Source URL must use http(s): {source}")
 
     if source:
+        max_bytes = 10 * 1024 * 1024  # 10 MiB cap on registry payload
         try:
             with urllib.request.urlopen(source, timeout=15) as resp:
-                remote_payload = json.loads(resp.read())
+                raw = resp.read(max_bytes + 1)
+            if len(raw) > max_bytes:
+                raise click.ClickException(
+                    f"Registry payload exceeds {max_bytes} bytes: {source}"
+                )
+            remote_payload = json.loads(raw)
             remote_models = parse_model_metadata(remote_payload)
         except (OSError, ValueError, urllib.error.URLError) as e:
             raise click.ClickException(str(e)) from e

--- a/nadirclaw/routing.py
+++ b/nadirclaw/routing.py
@@ -177,7 +177,7 @@ def _merge_external_model_metadata() -> None:
             continue
         try:
             models = load_model_metadata(path)
-        except Exception as e:
+        except (OSError, ValueError) as e:
             logger.warning("Skipping invalid model metadata file %s: %s", path, e)
             continue
         for model_id, info in models.items():

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -491,6 +491,43 @@ class TestLocalModelMetadata:
         finally:
             MODEL_REGISTRY.pop(model, None)
 
+    def test_local_overrides_generated(self, tmp_path, monkeypatch):
+        generated = tmp_path / "models.json"
+        local = tmp_path / "models.local.json"
+        model = "custom/override-me"
+        generated.write_text(json.dumps({
+            "models": {
+                model: {"context_window": 1000, "cost_per_m_input": 1.0,
+                        "cost_per_m_output": 2.0, "has_vision": False},
+            }
+        }))
+        local.write_text(json.dumps({
+            "models": {
+                model: {"context_window": 5000, "cost_per_m_input": 0.5},
+            }
+        }))
+        monkeypatch.setenv("NADIRCLAW_MODEL_METADATA_FILE", str(generated))
+        monkeypatch.setenv("NADIRCLAW_LOCAL_MODEL_METADATA_FILE", str(local))
+
+        try:
+            _merge_external_model_metadata()
+            assert get_context_window(model) == 5000
+            info = MODEL_REGISTRY[model]
+            assert info["cost_per_m_input"] == 0.5
+            assert info["cost_per_m_output"] == 2.0
+        finally:
+            MODEL_REGISTRY.pop(model, None)
+
+    def test_invalid_metadata_file_is_skipped(self, tmp_path, monkeypatch, caplog):
+        path = tmp_path / "models.json"
+        path.write_text("{not valid json")
+        monkeypatch.setenv("NADIRCLAW_MODEL_METADATA_FILE", str(path))
+        monkeypatch.setenv("NADIRCLAW_LOCAL_MODEL_METADATA_FILE", str(tmp_path / "missing.json"))
+
+        with caplog.at_level("WARNING", logger="nadirclaw.routing"):
+            _merge_external_model_metadata()
+        assert any("Skipping invalid model metadata file" in r.message for r in caplog.records)
+
 
 # ---------------------------------------------------------------------------
 # apply_routing_modifiers

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -549,12 +549,11 @@ class TestSetupCLI:
         assert not output.exists()
         assert "Would write" in result.output
 
-    def test_update_models_source_url(self, tmp_path):
+    def test_update_models_source_url(self, tmp_path, monkeypatch):
         from nadirclaw.cli import main
 
-        source = tmp_path / "source.json"
         output = tmp_path / "models.json"
-        source.write_text(json.dumps({
+        payload = json.dumps({
             "models": {
                 "custom/source-model": {
                     "context_window": 12345,
@@ -563,17 +562,50 @@ class TestSetupCLI:
                     "has_vision": False,
                 }
             }
-        }))
+        }).encode()
 
+        class _FakeResponse:
+            def __init__(self, body):
+                self._body = body
+            def read(self, size=-1):
+                if size is None or size < 0:
+                    body, self._body = self._body, b""
+                    return body
+                body, self._body = self._body[:size], self._body[size:]
+                return body
+            def __enter__(self):
+                return self
+            def __exit__(self, *_):
+                return False
+
+        def fake_urlopen(url, timeout=None):
+            assert url == "https://example.test/models.json"
+            return _FakeResponse(payload)
+
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
         runner = CliRunner()
         result = runner.invoke(
             main,
-            ["update-models", "--output", str(output), "--source-url", source.as_uri()],
+            ["update-models", "--output", str(output), "--source-url", "https://example.test/models.json"],
         )
 
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         models = load_model_metadata(output)
         assert models["custom/source-model"]["context_window"] == 12345
+
+    def test_update_models_cli_source_requires_http(self, tmp_path):
+        from nadirclaw.cli import main
+
+        output = tmp_path / "models.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["update-models", "--output", str(output), "--source-url", "file:///etc/passwd"],
+        )
+
+        assert result.exit_code != 0
+        assert "Source URL must use http(s)" in result.output
+        assert not output.exists()
 
     def test_update_models_env_source_requires_http(self, tmp_path, monkeypatch):
         from nadirclaw.cli import main
@@ -587,6 +619,28 @@ class TestSetupCLI:
         assert result.exit_code != 0
         assert "Source URL must use http(s)" in result.output
         assert not output.exists()
+
+    def test_update_models_rejects_oversized_payload(self, tmp_path, monkeypatch):
+        from nadirclaw.cli import main
+
+        class _BigResponse:
+            def read(self, size=-1):
+                return b"x" * (size if size and size > 0 else 1)
+            def __enter__(self):
+                return self
+            def __exit__(self, *_):
+                return False
+
+        monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: _BigResponse())
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["update-models", "--output", str(tmp_path / "models.json"),
+             "--source-url", "https://example.test/big.json"],
+        )
+
+        assert result.exit_code != 0
+        assert "exceeds" in result.output
 
     def test_update_models_source_failure_is_click_error(self, tmp_path, monkeypatch):
         import urllib.error


### PR DESCRIPTION
## Summary

Follow-up to #42 (now merged) addressing the three nice-to-haves I called out in the #42 approval comment:

- **CLI scheme parity** — `--source-url` now enforces the same `http(s)` check the env var `NADIRCLAW_MODEL_REGISTRY_URL` already had, closing a CLI path that allowed `file://`, `ftp://`, etc.
- **Payload size cap** — registry responses are read up to 10 MiB; anything larger fails with a `ClickException` instead of OOMing the process.
- **Narrower exception handler** — `_merge_external_model_metadata` now only swallows `(OSError, ValueError)`; programming errors propagate instead of being logged as malformed-file warnings (`json.JSONDecodeError` is a `ValueError` subclass, so the warn path still fires).

Tests updated: replace the `file://` fixture with a mocked `urlopen`; add coverage for the new CLI scheme rejection, the size cap, `models.local.json` override precedence over `models.json`, and the malformed-metadata warning path.

## Test plan

- [x] `python3 -m pytest tests/test_routing.py tests/test_setup.py` — 165 passed
- [ ] Full test suite in CI

---
_Rebased onto current `main` after #42 landed; only the targeted follow-up fixes remain in this branch._