### PR TITLE
feat: log per-model fallback reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to NadirClaw will be documented in this file.
 - **`nadirclaw update-models` command** — writes refreshable model metadata to `~/.nadirclaw/models.json`, optionally merging a published registry JSON via `--source-url` or `NADIRCLAW_MODEL_REGISTRY_URL`.
 - **Local model metadata overrides** — the router now merges `~/.nadirclaw/models.json` and user-managed `~/.nadirclaw/models.local.json` into the runtime model registry.
 - **DeepSeek V4 explicit aliases** — added `deepseek-v4`, `deepseek-v4-flash`, and `deepseek-v4-pro` while preserving the existing `deepseek` alias for `deepseek/deepseek-chat`.
+- **Fallback reasons logging** — failed fallback attempts now record ordered per-model `fallback_reasons` with compact error types and sanitized messages.
 
 ## [0.14.0] - 2026-04-03
 

--- a/nadirclaw/request_logger.py
+++ b/nadirclaw/request_logger.py
@@ -64,6 +64,7 @@ def _init_db() -> None:
                     daily_spend REAL,
                     response_preview TEXT,
                     fallback_used TEXT,
+                    fallback_reasons TEXT,
                     error TEXT,
                     tool_count INTEGER,
                     has_images INTEGER,
@@ -93,6 +94,7 @@ def _init_db() -> None:
                 ("optimized_tokens", "INTEGER"),
                 ("tokens_saved", "INTEGER"),
                 ("optimizations_applied", "TEXT"),
+                ("fallback_reasons", "TEXT"),
             ]:
                 try:
                     cursor.execute(f"ALTER TABLE requests ADD COLUMN {col} {col_type}")
@@ -141,6 +143,11 @@ def log_request(entry: Dict[str, Any]) -> None:
     daily_spend = entry.get("daily_spend")
     response_preview = entry.get("response_preview")
     fallback_used = entry.get("fallback_used")
+    fallback_reasons = (
+        json.dumps(entry["fallback_reasons"])
+        if entry.get("fallback_reasons")
+        else None
+    )
     error = entry.get("error")
     tool_count = entry.get("tool_count")
     has_images = 1 if entry.get("has_images") else 0
@@ -165,16 +172,16 @@ def log_request(entry: Dict[str, Any]) -> None:
                     timestamp, request_id, type, status, prompt, selected_model,
                     provider, tier, confidence, complexity_score, classifier_latency_ms,
                     total_latency_ms, prompt_tokens, completion_tokens, total_tokens,
-                    cost, daily_spend, response_preview, fallback_used, error,
+                    cost, daily_spend, response_preview, fallback_used, fallback_reasons, error,
                     tool_count, has_images, has_tools, max_context_tokens,
                     optimization_mode, original_tokens, optimized_tokens,
                     tokens_saved, optimizations_applied
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 timestamp, request_id, req_type, status, prompt, selected_model,
                 provider, tier, confidence, complexity_score, classifier_latency_ms,
                 total_latency_ms, prompt_tokens, completion_tokens, total_tokens,
-                cost, daily_spend, response_preview, fallback_used, error,
+                cost, daily_spend, response_preview, fallback_used, fallback_reasons, error,
                 tool_count, has_images, has_tools, max_context_tokens,
                 optimization_mode, original_tokens, optimized_tokens,
                 tokens_saved, optimizations_applied,

--- a/nadirclaw/server.py
+++ b/nadirclaw/server.py
@@ -30,6 +30,15 @@ from nadirclaw.settings import settings
 logger = logging.getLogger("nadirclaw")
 
 
+def _fallback_reason(model: str, error: Exception) -> Dict[str, str]:
+    """Build a compact, log-safe fallback failure reason."""
+    return {
+        "model": model,
+        "error_type": type(error).__name__,
+        "message": str(error)[:200].replace("\n", " "),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Exceptions
 # ---------------------------------------------------------------------------
@@ -1006,6 +1015,9 @@ async def _call_with_fallback(
             raise primary_error
 
         failed_models = [selected_model]
+        analysis_info.setdefault("fallback_reasons", []).append(
+            _fallback_reason(selected_model, primary_error)
+        )
         last_error = primary_error
 
         for fallback_model in chain:
@@ -1035,6 +1047,9 @@ async def _call_with_fallback(
                 if isinstance(chain_error, HTTPException):
                     raise
                 failed_models.append(fallback_model)
+                analysis_info.setdefault("fallback_reasons", []).append(
+                    _fallback_reason(fallback_model, chain_error)
+                )
                 last_error = chain_error
                 continue
 
@@ -1353,6 +1368,7 @@ async def chat_completions(
                     "daily_spend": budget_status["daily_spend"],
                     "response_preview": "[streamed]",
                     "fallback_used": _stream_analysis.get("fallback_from"),
+                    "fallback_reasons": _stream_analysis.get("fallback_reasons", []),
                     "streaming": True,
                     "status": "error" if _stream_analysis.get("_stream_error") else "ok",
                     **_stream_req_meta,
@@ -1424,6 +1440,7 @@ async def chat_completions(
             "daily_spend": budget_status["daily_spend"],
             "response_preview": (response_data["content"] or "")[:100],
             "fallback_used": analysis_info.get("fallback_from"),
+            "fallback_reasons": analysis_info.get("fallback_reasons", []),
             "status": "ok",
             **req_meta,
             **(optimization_info or {}),
@@ -1984,6 +2001,9 @@ async def _stream_with_fallback(
                 return
 
             # Pre-content failure — can try fallback
+            analysis_info.setdefault("fallback_reasons", []).append(
+                _fallback_reason(model, e)
+            )
             failed_models.append(model)
             last_error = e
             continue

--- a/tests/test_fallback_chain.py
+++ b/tests/test_fallback_chain.py
@@ -132,6 +132,11 @@ class TestFallbackChainBehavior:
         assert updated_info["fallback_from"] == "model-primary"
         assert "+fallback" in updated_info["strategy"]
         assert call_count["count"] == 2  # primary + backup
+        assert updated_info["fallback_reasons"] == [{
+            "model": "model-primary",
+            "error_type": "RateLimitExhausted",
+            "message": "Rate limit exhausted for model-primary (retry in 60s)",
+        }]
 
     @pytest.mark.asyncio
     async def test_fallback_cascade_through_chain(self, monkeypatch):

--- a/tests/test_request_logger.py
+++ b/tests/test_request_logger.py
@@ -2,6 +2,7 @@
 Tests for the SQLite request logger - basic smoke test.
 """
 
+import json
 import sqlite3
 import tempfile
 from pathlib import Path
@@ -42,6 +43,11 @@ def test_basic_logging_works():
                 "cost": 0.0015,
                 "daily_spend": 0.45,
                 "response_preview": "Hello! How can I help?",
+                "fallback_reasons": [{
+                    "model": "model-primary",
+                    "error_type": "RateLimitExhausted",
+                    "message": "Rate limit exhausted for model-primary (retry in 60s)",
+                }],
             }
             
             request_logger.log_request(entry)
@@ -52,13 +58,17 @@ def test_basic_logging_works():
             conn = sqlite3.connect(str(temp_db))
             cursor = conn.cursor()
             
-            cursor.execute("SELECT request_id, selected_model, cost FROM requests WHERE request_id = ?", ("test-123",))
+            cursor.execute(
+                "SELECT request_id, selected_model, cost, fallback_reasons FROM requests WHERE request_id = ?",
+                ("test-123",),
+            )
             row = cursor.fetchone()
             
             assert row is not None
             assert row[0] == "test-123"
             assert row[1] == "gpt-3.5-turbo"
             assert row[2] == 0.0015
+            assert json.loads(row[3]) == entry["fallback_reasons"]
             
             conn.close()
             


### PR DESCRIPTION
## Summary

Adds producer-side logging for per-model fallback reasons.

This records an ordered `fallback_reasons` list when fallback candidates fail, so the dashboard work in #41 and the follow-up provider-health work can share the same failure signal.

Each fallback reason includes:

- `model`
- `error_type = type(err).__name__`
- `message = str(err)[:200].replace("\n", " ")`

## Scope

- Record non-streaming primary fallback failure reasons
- Record non-streaming fallback-chain failure reasons
- Record streaming pre-content fallback failure reasons
- Skip mid-stream failures in this PR
- Include `fallback_reasons` in request log entries
- Persist `fallback_reasons` to SQLite as JSON text
- Add focused tests for fallback reason shape and SQLite persistence

## Non-goals

- No provider-health routing behavior
- No dashboard UI changes
- No mid-stream interruption schema

## Testing

- `/opt/anaconda3/envs/myenv/bin/python -m pytest tests/test_fallback_chain.py tests/test_request_logger.py -q`
- `/opt/anaconda3/envs/myenv/bin/python -m pytest -q`
