### PR TITLE
feat: add provider health-aware fallback routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to NadirClaw will be documented in this file.
 - **Local model metadata overrides** — the router now merges `~/.nadirclaw/models.json` and user-managed `~/.nadirclaw/models.local.json` into the runtime model registry.
 - **DeepSeek V4 explicit aliases** — added `deepseek-v4`, `deepseek-v4-flash`, and `deepseek-v4-pro` while preserving the existing `deepseek` alias for `deepseek/deepseek-chat`.
 - **Fallback reasons logging** — failed fallback attempts now record ordered per-model `fallback_reasons` with compact error types and sanitized messages.
+- **Provider health-aware fallback routing** — optional `NADIRCLAW_PROVIDER_HEALTH=true` mode tracks in-process model health and tries healthy fallback candidates before cooling-down ones.
 
 ## [0.14.0] - 2026-04-03
 

--- a/nadirclaw/provider_health.py
+++ b/nadirclaw/provider_health.py
@@ -1,0 +1,127 @@
+"""In-memory provider health tracking for fallback routing."""
+
+from __future__ import annotations
+
+import collections
+import time
+from typing import Any
+
+
+HEALTH_FAILURE_TYPES = {
+    "APIConnectionError",
+    "BadGatewayError",
+    "ConnectError",
+    "ConnectTimeout",
+    "ReadTimeout",
+    "Timeout",
+}
+
+
+class ProviderHealthTracker:
+    """Rolling in-process health tracker keyed by model name."""
+
+    def __init__(
+        self,
+        *,
+        failure_threshold: int = 2,
+        cooldown_seconds: int = 60,
+        max_models: int = 128,
+        now_func=time.time,
+    ):
+        self.failure_threshold = max(1, failure_threshold)
+        self.cooldown_seconds = max(1, cooldown_seconds)
+        self.max_models = max(1, max_models)
+        self._now = now_func
+        self._models: collections.OrderedDict[str, dict[str, Any]] = collections.OrderedDict()
+
+    def record_success(self, model: str) -> None:
+        state = self._state_for(model)
+        state["recent_successes"] += 1
+        state["consecutive_failures"] = 0
+        state["cooldown_until"] = 0.0
+        state["status"] = "healthy"
+
+    def record_failure(self, model: str, error_type: str, message: str = "") -> None:
+        state = self._state_for(model)
+        state["last_error"] = {"error_type": error_type, "message": message}
+        if not self._counts_as_health_failure(error_type):
+            return
+
+        state["recent_failures"] += 1
+        state["consecutive_failures"] += 1
+        if state["consecutive_failures"] >= self.failure_threshold:
+            state["cooldown_until"] = self._now() + self.cooldown_seconds
+            state["status"] = "cooling_down"
+
+    def ordered_candidates(self, models: list[str]) -> list[str]:
+        healthy: list[str] = []
+        unhealthy: list[str] = []
+        for model in models:
+            if self.is_available(model):
+                healthy.append(model)
+            else:
+                unhealthy.append(model)
+        return healthy + unhealthy
+
+    def is_available(self, model: str) -> bool:
+        state = self._models.get(model)
+        if not state:
+            return True
+        cooldown_until = state.get("cooldown_until", 0.0)
+        return not cooldown_until or self._now() >= cooldown_until
+
+    def snapshot(self) -> dict[str, Any]:
+        models: dict[str, Any] = {}
+        now = self._now()
+        for model, state in self._models.items():
+            cooldown_until = state.get("cooldown_until", 0.0)
+            if cooldown_until and now < cooldown_until:
+                status = "cooling_down"
+            elif state.get("consecutive_failures", 0) >= self.failure_threshold:
+                status = "unhealthy"
+            else:
+                status = "healthy"
+            models[model] = {
+                "recent_failures": state["recent_failures"],
+                "recent_successes": state["recent_successes"],
+                "status": status,
+                "last_error": state.get("last_error"),
+            }
+            if cooldown_until and now < cooldown_until:
+                models[model]["cooldown_seconds_remaining"] = int(cooldown_until - now) + 1
+        return {"models": models}
+
+    def reset(self) -> None:
+        self._models.clear()
+
+    def _state_for(self, model: str) -> dict[str, Any]:
+        state = self._models.get(model)
+        if state is None:
+            state = {
+                "recent_failures": 0,
+                "recent_successes": 0,
+                "consecutive_failures": 0,
+                "cooldown_until": 0.0,
+                "status": "healthy",
+                "last_error": None,
+            }
+            self._models[model] = state
+        else:
+            self._models.move_to_end(model)
+
+        while len(self._models) > self.max_models:
+            self._models.popitem(last=False)
+        return state
+
+    @staticmethod
+    def _counts_as_health_failure(error_type: str) -> bool:
+        if error_type in HEALTH_FAILURE_TYPES:
+            return True
+        if error_type.endswith("ServerError"):
+            return True
+        if error_type in {"InternalServerError", "ServiceUnavailableError"}:
+            return True
+        return False
+
+
+provider_health_tracker = ProviderHealthTracker()

--- a/nadirclaw/server.py
+++ b/nadirclaw/server.py
@@ -39,6 +39,37 @@ def _fallback_reason(model: str, error: Exception) -> Dict[str, str]:
     }
 
 
+def _record_provider_success(model: str) -> None:
+    if settings.PROVIDER_HEALTH is not True:
+        return
+    provider_health_tracker = _provider_health_tracker()
+    provider_health_tracker.record_success(model)
+
+
+def _record_provider_failure(model: str, error: Exception) -> None:
+    if settings.PROVIDER_HEALTH is not True:
+        return
+    provider_health_tracker = _provider_health_tracker()
+    reason = _fallback_reason(model, error)
+    provider_health_tracker.record_failure(model, reason["error_type"], reason["message"])
+
+
+def _order_fallback_candidates(chain: list[str]) -> list[str]:
+    if settings.PROVIDER_HEALTH is not True:
+        return chain
+    provider_health_tracker = _provider_health_tracker()
+    return provider_health_tracker.ordered_candidates(chain)
+
+
+def _provider_health_tracker():
+    from nadirclaw.provider_health import provider_health_tracker
+    failure_threshold = settings.PROVIDER_HEALTH_FAILURE_THRESHOLD
+    cooldown_seconds = settings.PROVIDER_HEALTH_COOLDOWN_SECONDS
+    provider_health_tracker.failure_threshold = failure_threshold if isinstance(failure_threshold, int) else 2
+    provider_health_tracker.cooldown_seconds = cooldown_seconds if isinstance(cooldown_seconds, int) else 60
+    return provider_health_tracker
+
+
 # ---------------------------------------------------------------------------
 # Exceptions
 # ---------------------------------------------------------------------------
@@ -999,15 +1030,17 @@ async def _call_with_fallback(
 
     try:
         response_data = await _dispatch_model(selected_model, request, provider)
+        _record_provider_success(selected_model)
         return response_data, selected_model, analysis_info
     except (RateLimitExhausted, Exception) as primary_error:
         if isinstance(primary_error, HTTPException):
             raise  # Don't fallback on validation/auth errors
+        _record_provider_failure(selected_model, primary_error)
 
         # Build fallback chain: use per-tier chain if configured, else global
         tier = analysis_info.get("tier", "")
         full_chain = settings.get_tier_fallback_chain(tier) if tier else settings.FALLBACK_CHAIN
-        chain = [m for m in full_chain if m != selected_model]
+        chain = _order_fallback_candidates([m for m in full_chain if m != selected_model])
 
         if not chain:
             if isinstance(primary_error, RateLimitExhausted):
@@ -1035,6 +1068,7 @@ async def _call_with_fallback(
                 response_data = await _dispatch_model(
                     fallback_model, request, fallback_provider,
                 )
+                _record_provider_success(fallback_model)
                 analysis_info = {
                     **analysis_info,
                     "fallback_from": selected_model,
@@ -1046,6 +1080,7 @@ async def _call_with_fallback(
             except (RateLimitExhausted, Exception) as chain_error:
                 if isinstance(chain_error, HTTPException):
                     raise
+                _record_provider_failure(fallback_model, chain_error)
                 failed_models.append(fallback_model)
                 analysis_info.setdefault("fallback_reasons", []).append(
                     _fallback_reason(fallback_model, chain_error)
@@ -1898,7 +1933,8 @@ async def _stream_with_fallback(
 
     tier = analysis_info.get("tier", "")
     full_chain = settings.get_tier_fallback_chain(tier) if tier else settings.FALLBACK_CHAIN
-    models_to_try = [selected_model] + [m for m in full_chain if m != selected_model]
+    fallback_chain = _order_fallback_candidates([m for m in full_chain if m != selected_model])
+    models_to_try = [selected_model] + fallback_chain
     created = int(time.time())
     failed_models: list[str] = []
     last_error: Exception | None = None
@@ -1957,6 +1993,8 @@ async def _stream_with_fallback(
             yield {"data": json.dumps(finish_chunk)}
             yield {"data": "[DONE]"}
 
+            _record_provider_success(model)
+
             # Update analysis_info in-place for logging
             if failed_models:
                 analysis_info["fallback_from"] = selected_model
@@ -1998,12 +2036,14 @@ async def _stream_with_fallback(
                 analysis_info["_stream_model"] = model
                 analysis_info["_stream_usage"] = accumulated_usage
                 analysis_info["_stream_error"] = str(e)
+                _record_provider_failure(model, e)
                 return
 
             # Pre-content failure — can try fallback
             analysis_info.setdefault("fallback_reasons", []).append(
                 _fallback_reason(model, e)
             )
+            _record_provider_failure(model, e)
             failed_models.append(model)
             last_error = e
             continue
@@ -2135,6 +2175,13 @@ async def health():
         "simple_model": settings.SIMPLE_MODEL,
         "complex_model": settings.COMPLEX_MODEL,
     }
+
+
+@app.get("/internal/provider_health")
+async def provider_health():
+    if settings.PROVIDER_HEALTH is not True:
+        raise HTTPException(status_code=404, detail="Not found")
+    return _provider_health_tracker().snapshot()
 
 
 @app.get("/")

--- a/nadirclaw/settings.py
+++ b/nadirclaw/settings.py
@@ -212,6 +212,27 @@ class Settings:
             return 0
 
     @property
+    def PROVIDER_HEALTH(self) -> bool:
+        """Enable health-aware fallback routing."""
+        return os.getenv("NADIRCLAW_PROVIDER_HEALTH", "").lower() in ("1", "true", "yes")
+
+    @property
+    def PROVIDER_HEALTH_COOLDOWN_SECONDS(self) -> int:
+        """Seconds to skip unhealthy fallback candidates before re-admitting them."""
+        try:
+            return max(1, int(os.getenv("NADIRCLAW_PROVIDER_HEALTH_COOLDOWN_SECONDS", "60")))
+        except ValueError:
+            return 60
+
+    @property
+    def PROVIDER_HEALTH_FAILURE_THRESHOLD(self) -> int:
+        """Consecutive health failures before a fallback candidate enters cooldown."""
+        try:
+            return max(1, int(os.getenv("NADIRCLAW_PROVIDER_HEALTH_FAILURE_THRESHOLD", "2")))
+        except ValueError:
+            return 2
+
+    @property
     def OPTIMIZE(self) -> str:
         """Context optimization mode: off, safe, aggressive. Default: off."""
         val = os.getenv("NADIRCLAW_OPTIMIZE", "off").lower()

--- a/tests/test_fallback_chain.py
+++ b/tests/test_fallback_chain.py
@@ -249,3 +249,95 @@ class TestFallbackChainBehavior:
 
         # Should return graceful error (since chain is exhausted after one model)
         assert "rate-limited" in response["content"].lower()
+
+    @pytest.mark.asyncio
+    async def test_provider_health_skips_unhealthy_fallback_candidate(self):
+        """Health-aware routing should try healthy fallback candidates first."""
+        from nadirclaw.provider_health import ProviderHealthTracker
+        from nadirclaw.server import _call_with_fallback
+
+        class MockRequest:
+            messages = []
+            stream = False
+            temperature = None
+            max_tokens = None
+            top_p = None
+            model_extra = {}
+
+        request = MockRequest()
+        analysis_info = {"tier": "complex", "strategy": "smart-routing"}
+        attempts = []
+        tracker = ProviderHealthTracker(failure_threshold=1, cooldown_seconds=60)
+        tracker.record_failure("m2", "ReadTimeout", "timed out")
+
+        async def mock_dispatch(model, req, provider):
+            attempts.append(model)
+            if model == "m1":
+                raise RuntimeError("primary failed")
+            return {
+                "content": f"Success from {model}",
+                "finish_reason": "stop",
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+            }
+
+        with patch("nadirclaw.server._dispatch_model", side_effect=mock_dispatch):
+            with patch("nadirclaw.server.settings") as mock_settings:
+                mock_settings.PROVIDER_HEALTH = True
+                mock_settings.FALLBACK_CHAIN = ["m1", "m2", "m3"]
+                mock_settings.get_tier_fallback_chain.return_value = ["m1", "m2", "m3"]
+                with patch("nadirclaw.provider_health.provider_health_tracker", tracker):
+                    response, actual_model, updated_info = await _call_with_fallback(
+                        "m1", request, None, analysis_info
+                    )
+
+        assert attempts == ["m1", "m3"]
+        assert actual_model == "m3"
+        assert response["content"] == "Success from m3"
+        assert updated_info["fallback_chain_tried"] == ["m1"]
+
+    @pytest.mark.asyncio
+    async def test_provider_health_tries_unhealthy_candidates_if_needed(self):
+        """Unhealthy candidates remain a last resort instead of causing early failure."""
+        from nadirclaw.provider_health import ProviderHealthTracker
+        from nadirclaw.server import _call_with_fallback
+
+        class MockRequest:
+            messages = []
+            stream = False
+            temperature = None
+            max_tokens = None
+            top_p = None
+            model_extra = {}
+
+        request = MockRequest()
+        analysis_info = {"tier": "complex", "strategy": "smart-routing"}
+        attempts = []
+        tracker = ProviderHealthTracker(failure_threshold=1, cooldown_seconds=60)
+        tracker.record_failure("m2", "ReadTimeout", "timed out")
+
+        async def mock_dispatch(model, req, provider):
+            attempts.append(model)
+            if model in {"m1", "m3"}:
+                raise RuntimeError(f"{model} failed")
+            return {
+                "content": f"Success from {model}",
+                "finish_reason": "stop",
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+            }
+
+        with patch("nadirclaw.server._dispatch_model", side_effect=mock_dispatch):
+            with patch("nadirclaw.server.settings") as mock_settings:
+                mock_settings.PROVIDER_HEALTH = True
+                mock_settings.FALLBACK_CHAIN = ["m1", "m2", "m3"]
+                mock_settings.get_tier_fallback_chain.return_value = ["m1", "m2", "m3"]
+                with patch("nadirclaw.provider_health.provider_health_tracker", tracker):
+                    response, actual_model, updated_info = await _call_with_fallback(
+                        "m1", request, None, analysis_info
+                    )
+
+        assert attempts == ["m1", "m3", "m2"]
+        assert actual_model == "m2"
+        assert response["content"] == "Success from m2"
+        assert updated_info["fallback_chain_tried"] == ["m1", "m3"]

--- a/tests/test_provider_health.py
+++ b/tests/test_provider_health.py
@@ -1,0 +1,48 @@
+"""Tests for provider health tracking."""
+
+from nadirclaw.provider_health import ProviderHealthTracker
+
+
+def test_health_failure_enters_cooldown_and_reorders_candidates():
+    now = [1000.0]
+    tracker = ProviderHealthTracker(
+        failure_threshold=2,
+        cooldown_seconds=30,
+        now_func=lambda: now[0],
+    )
+
+    tracker.record_failure("model-a", "ReadTimeout", "timed out")
+    assert tracker.ordered_candidates(["model-a", "model-b"]) == ["model-a", "model-b"]
+
+    tracker.record_failure("model-a", "ConnectTimeout", "connect timed out")
+    assert tracker.ordered_candidates(["model-a", "model-b"]) == ["model-b", "model-a"]
+    assert tracker.snapshot()["models"]["model-a"]["status"] == "cooling_down"
+
+    now[0] = 1031.0
+    assert tracker.ordered_candidates(["model-a", "model-b"]) == ["model-a", "model-b"]
+
+
+def test_rate_limit_does_not_trip_health_bit():
+    tracker = ProviderHealthTracker(failure_threshold=1, cooldown_seconds=30)
+
+    tracker.record_failure("model-a", "RateLimitExhausted", "rate limited")
+
+    assert tracker.ordered_candidates(["model-a", "model-b"]) == ["model-a", "model-b"]
+    snapshot = tracker.snapshot()["models"]["model-a"]
+    assert snapshot["recent_failures"] == 0
+    assert snapshot["status"] == "healthy"
+    assert snapshot["last_error"]["error_type"] == "RateLimitExhausted"
+
+
+def test_success_resets_cooldown():
+    tracker = ProviderHealthTracker(failure_threshold=1, cooldown_seconds=30)
+
+    tracker.record_failure("model-a", "ReadTimeout", "timed out")
+    assert tracker.ordered_candidates(["model-a", "model-b"]) == ["model-b", "model-a"]
+
+    tracker.record_success("model-a")
+
+    assert tracker.ordered_candidates(["model-a", "model-b"]) == ["model-a", "model-b"]
+    snapshot = tracker.snapshot()["models"]["model-a"]
+    assert snapshot["recent_successes"] == 1
+    assert snapshot["status"] == "healthy"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -30,6 +30,18 @@ class TestHealthEndpoint:
         assert data["status"] == "ok"
         assert "version" in data
 
+    def test_provider_health_hidden_by_default(self, client):
+        resp = client.get("/internal/provider_health")
+        assert resp.status_code == 404
+
+    def test_provider_health_returns_snapshot_when_enabled(self, client):
+        with patch("nadirclaw.server.settings") as mock_settings:
+            mock_settings.PROVIDER_HEALTH = True
+            resp = client.get("/internal/provider_health")
+
+        assert resp.status_code == 200
+        assert "models" in resp.json()
+
 
 class TestModelsEndpoint:
     def test_list_models(self, client):


### PR DESCRIPTION
## Summary
- add opt-in in-process provider health tracking behind NADIRCLAW_PROVIDER_HEALTH=true
- prefer healthy fallback candidates while keeping cooling-down models as a last resort
- expose /internal/provider_health only when provider health routing is enabled

## Scope
- primary model selection is unchanged; health ordering only applies to fallback candidates
- RateLimitExhausted / 429 is recorded but does not trip the unhealthy bit in v1
- timeouts, connection errors, and provider 5xx-style errors count as health failures
- health state is in-memory only and is not persisted across restarts

## Testing
- /opt/anaconda3/envs/myenv/bin/python -m pytest tests/test_provider_health.py tests/test_fallback_chain.py tests/test_server.py tests/test_streaming_fallback.py -q
- /opt/anaconda3/envs/myenv/bin/python -m pytest -q