### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,19 @@ All notable changes to NadirClaw will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-05-09
+
 ### Added
 - **`nadirclaw update-models` command** — writes refreshable model metadata to `~/.nadirclaw/models.json`, optionally merging a published registry JSON via `--source-url` or `NADIRCLAW_MODEL_REGISTRY_URL`.
 - **Local model metadata overrides** — the router now merges `~/.nadirclaw/models.json` and user-managed `~/.nadirclaw/models.local.json` into the runtime model registry.
 - **DeepSeek V4 explicit aliases** — added `deepseek-v4`, `deepseek-v4-flash`, and `deepseek-v4-pro` while preserving the existing `deepseek` alias for `deepseek/deepseek-chat`.
-- **Fallback reasons logging** — failed fallback attempts now record ordered per-model `fallback_reasons` with compact error types and sanitized messages.
-- **Provider health-aware fallback routing** — optional `NADIRCLAW_PROVIDER_HEALTH=true` mode tracks in-process model health and tries healthy fallback candidates before cooling-down ones.
+- **Model pool weighted load balancing** — pool tier configuration with weighted round-robin across multiple models in the same tier (#36).
+- **Selective context compression module** — opt-in compression for tool-heavy contexts (#40).
+- **Complex coding detection and enhanced reasoning markers** — improved tier classification for coding-heavy prompts and Chinese reasoning markers (#38).
+- **Upgrade-only session cache for agent frameworks** — caches routing decisions per session to avoid repeated downgrades on multi-turn agent flows (#27).
+- **Agent role detection for AI coding assistants** — recognizes Claude Code / Cursor-style system prompts and routes accordingly (#37/#45).
+- **Fallback reasons logging** — failed fallback attempts now record ordered per-model `fallback_reasons` with compact error types and sanitized messages (#47).
+- **Provider health-aware fallback routing** — optional `NADIRCLAW_PROVIDER_HEALTH=true` mode tracks in-process model health and tries healthy fallback candidates before cooling-down ones; debug snapshot via `/internal/provider_health` (#48).
 
 ## [0.14.0] - 2026-04-03
 

--- a/nadirclaw/__init__.py
+++ b/nadirclaw/__init__.py
@@ -1,3 +1,3 @@
 """NadirClaw — Open-source LLM router."""
 
-__version__ = "0.14.3"
+__version__ = "0.15.0"


### PR DESCRIPTION
## Summary

Bundles all changes since `0.14.0` into a minor version bump. The unreleased section in `CHANGELOG.md` had piled up across 7 merged PRs; this consolidates them and ships.

### What's in 0.15.0

- **#36** — Model pool weighted load balancing
- **#27** — Upgrade-only session cache for agent frameworks
- **#38** — Complex coding detection + Chinese reasoning markers
- **#40** — Selective context compression module
- **#42 / #43** — `update-models` command + local metadata overrides + DeepSeek V4 aliases
- **#37 / #45** — Agent role detection for AI coding assistants
- **#47** — Fallback reasons logging (per-model error type + sanitized message)
- **#48** — Provider health-aware fallback routing (opt-in via `NADIRCLAW_PROVIDER_HEALTH=true`)

### Verification

- Full test suite locally on `95cf351`: `568 passed` in 53s
- CI green on Python 3.10 / 3.11 / 3.12 for the latest merged PR (#48)

### Notes

- Patch versions `0.14.1` / `0.14.2` / `0.14.3` (already released to PyPI) don't have explicit `CHANGELOG.md` entries — kept that convention here. If you'd like them backfilled, happy to do it as a follow-up; the commit messages are descriptive enough to derive entries from (`v0.14.1` OAuth interop, `v0.14.2` Vertex AI mode, `v0.14.3` log rotation).
- After merge: tag `v0.15.0` and create a GitHub release. I can do the tag + release as a follow-up step once you've merged this.

## Test plan
- [ ] CI passes (3.10 / 3.11 / 3.12 matrix)
- [ ] Version reads `0.15.0` from `nadirclaw/__init__.py`
- [ ] CHANGELOG entry accurately reflects the 8 PRs landed since 0.14.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)