### PR TITLE
Add configurable embedding backends

### DIFF
--- a/nadirclaw/classifier.py
+++ b/nadirclaw/classifier.py
@@ -3,11 +3,22 @@ Binary complexity classifier using sentence embedding prototypes.
 
 Classifies prompts as simple or complex by comparing their embeddings
 to pre-computed centroid vectors shipped with the package.
+
+Centroid files and optional metadata are loaded from:
+  - The package directory (default, backward-compatible)
+  - A custom directory set via NADIRCLAW_CENTROID_DIR
+
+When a custom centroid directory is used, a centroid_metadata.json file is
+required. If metadata is present (in either location), the backend, model,
+and dimension are validated against the current encoder configuration to
+prevent silent mismatch between centroid vectors and the active embedding model.
 """
 
+import json
 import logging
 import os
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -21,38 +32,148 @@ class BinaryComplexityClassifier:
     """
     Classifies prompts as simple or complex using semantic prototype centroids.
 
-    Loads pre-computed centroid vectors from .npy files (shipped with the
-    package). At inference time, embeds the prompt (~10 ms on warm encoder),
-    computes cosine similarity to both centroids, and returns a binary
-    decision with a confidence score.
+    Loads pre-computed centroid vectors from .npy files and validates them
+    against centroid_metadata.json if present. At inference time, embeds the
+    prompt (~10 ms on warm encoder), computes cosine similarity to both
+    centroids, and returns a binary decision with a confidence score.
     """
 
     def __init__(self):
         from nadirclaw.encoder import get_shared_encoder_sync
+        from nadirclaw.settings import settings
 
         self.encoder = get_shared_encoder_sync()
-        self._simple_centroid, self._complex_centroid = self._load_centroids()
+        self._simple_centroid, self._complex_centroid = self._load_centroids(
+            encoder=self.encoder,
+            settings=settings,
+        )
 
         logger.info("BinaryComplexityClassifier ready (pre-computed centroids)")
 
     # ------------------------------------------------------------------
-    # Load pre-computed centroids
+    # Load and validate pre-computed centroids
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _load_centroids() -> Tuple[np.ndarray, np.ndarray]:
-        """Load pre-computed centroid vectors from .npy files."""
-        simple_path = os.path.join(_PKG_DIR, "simple_centroid.npy")
-        complex_path = os.path.join(_PKG_DIR, "complex_centroid.npy")
+    def _load_centroids(encoder=None, settings=None) -> Tuple[np.ndarray, np.ndarray]:
+        """Load centroid vectors and validate metadata if present.
 
-        if not os.path.exists(simple_path) or not os.path.exists(complex_path):
+        Args:
+            encoder: Current encoder instance (used for dimension check).
+            settings: Settings instance (used to read CENTROID_DIR and
+                      EMBEDDING_BACKEND/MODEL for mismatch reporting).
+
+        Raises:
+            FileNotFoundError: Centroid files or required metadata missing.
+            RuntimeError: Backend/model/dimension mismatch detected.
+            ValueError: Centroid files have inconsistent dimensions.
+        """
+        if settings is None:
+            from nadirclaw.settings import settings as _settings
+            settings = _settings
+
+        custom_dir = settings.CENTROID_DIR
+        if custom_dir is not None:
+            centroid_dir = Path(custom_dir)
+            require_metadata = True
+        else:
+            centroid_dir = Path(_PKG_DIR)
+            require_metadata = False
+
+        simple_path = centroid_dir / "simple_centroid.npy"
+        complex_path = centroid_dir / "complex_centroid.npy"
+        meta_path = centroid_dir / "centroid_metadata.json"
+
+        if not simple_path.exists() or not complex_path.exists():
+            if custom_dir is not None:
+                raise FileNotFoundError(
+                    f"Centroid files not found in {centroid_dir}. "
+                    f"Run: nadirclaw build-centroids "
+                    f"--embedding-backend {settings.EMBEDDING_BACKEND} "
+                    f"--embedding-model {settings.EMBEDDING_MODEL} "
+                    f"--output-dir {centroid_dir}"
+                )
             raise FileNotFoundError(
                 "Pre-computed centroid files not found. "
                 "Run 'nadirclaw build-centroids' to generate them."
             )
 
-        simple_centroid = np.load(simple_path)
-        complex_centroid = np.load(complex_path)
+        simple_centroid = np.load(str(simple_path))
+        complex_centroid = np.load(str(complex_path))
+
+        # Both centroid arrays must have the same shape
+        if simple_centroid.shape != complex_centroid.shape:
+            raise ValueError(
+                f"Centroid dimension mismatch: "
+                f"simple={simple_centroid.shape}, complex={complex_centroid.shape}. "
+                f"Rebuild centroids with 'nadirclaw build-centroids'."
+            )
+
+        current_backend = settings.EMBEDDING_BACKEND
+        current_model = settings.EMBEDDING_MODEL
+
+        if meta_path.exists():
+            # Validate metadata when present (in any directory)
+            with open(meta_path) as fh:
+                meta = json.load(fh)
+
+            meta_backend = meta.get("embedding_backend", "")
+            meta_model = meta.get("embedding_model", "")
+            meta_dim = meta.get("dimension")
+
+            if meta_backend and meta_backend != current_backend:
+                raise RuntimeError(
+                    f"Centroid/encoder mismatch: centroids were built with backend "
+                    f"{meta_backend!r} but current backend is {current_backend!r}. "
+                    f"Rebuild with:\n"
+                    f"  nadirclaw build-centroids "
+                    f"--embedding-backend {current_backend} "
+                    f"--embedding-model {current_model}"
+                    + (f" --output-dir {centroid_dir}" if custom_dir is not None else "")
+                )
+
+            if meta_model and meta_model != current_model:
+                raise RuntimeError(
+                    f"Centroid/encoder mismatch: centroids were built for model "
+                    f"{meta_model!r} but current model is {current_model!r}. "
+                    f"Rebuild with:\n"
+                    f"  nadirclaw build-centroids "
+                    f"--embedding-backend {current_backend} "
+                    f"--embedding-model {current_model}"
+                    + (f" --output-dir {centroid_dir}" if custom_dir is not None else "")
+                )
+
+            if meta_dim is not None and simple_centroid.shape[0] != meta_dim:
+                raise RuntimeError(
+                    f"Centroid dimension in metadata ({meta_dim}) does not match "
+                    f"actual centroid dimension ({simple_centroid.shape[0]}). "
+                    f"Rebuild centroids with 'nadirclaw build-centroids'."
+                )
+
+        elif require_metadata:
+            # Custom dir without metadata — fail closed for safety
+            raise FileNotFoundError(
+                f"No centroid_metadata.json found in {centroid_dir}. "
+                f"Custom centroid directories require metadata for safe validation. "
+                f"Rebuild with:\n"
+                f"  nadirclaw build-centroids "
+                f"--embedding-backend {current_backend} "
+                f"--embedding-model {current_model} "
+                f"--output-dir {centroid_dir}"
+            )
+
+        # Encoder dimension check (skipped for Ollama before first encode call)
+        if encoder is not None and encoder.dimension is not None:
+            enc_dim = encoder.dimension
+            if enc_dim != simple_centroid.shape[0]:
+                raise RuntimeError(
+                    f"Encoder output dimension ({enc_dim}) does not match "
+                    f"centroid dimension ({simple_centroid.shape[0]}). "
+                    f"Rebuild centroids with the current embedding model:\n"
+                    f"  nadirclaw build-centroids "
+                    f"--embedding-backend {current_backend} "
+                    f"--embedding-model {current_model}"
+                )
 
         return simple_centroid, complex_centroid
 

--- a/nadirclaw/cli.py
+++ b/nadirclaw/cli.py
@@ -569,19 +569,75 @@ def export(fmt, since, model, output_path):
 
 
 @main.command(name="build-centroids")
-def build_centroids():
-    """Regenerate centroid .npy files from prototype prompts."""
+@click.option(
+    "--embedding-backend", default=None,
+    help="Embedding backend: sentence-transformers (default) or ollama.",
+)
+@click.option(
+    "--embedding-model", default=None,
+    help="Embedding model ID (default: all-MiniLM-L6-v2 for sentence-transformers).",
+)
+@click.option(
+    "--embedding-api-base", default=None,
+    help="Base URL for the embedding API (used by the ollama backend).",
+)
+@click.option(
+    "--output-dir", default=None, type=click.Path(path_type=Path),
+    help=(
+        "Directory to write centroid files (default: package directory). "
+        "Set NADIRCLAW_CENTROID_DIR to the same path when using the server."
+    ),
+)
+def build_centroids(embedding_backend, embedding_model, embedding_api_base, output_dir):
+    """Regenerate centroid .npy files and metadata from prototype prompts.
+
+    By default, writes to the package directory using the configured embedding
+    backend and model (sentence-transformers/all-MiniLM-L6-v2 unless overridden
+    by env vars or the CLI flags below).
+
+    Examples::
+
+        # Default: rebuild package centroids with all-MiniLM-L6-v2
+        nadirclaw build-centroids
+
+        # Custom backend: build nomic-embed-text centroids into ~/.nadirclaw/centroids/nomic
+        nadirclaw build-centroids \\
+          --embedding-backend ollama \\
+          --embedding-model nomic-embed-text \\
+          --embedding-api-base http://127.0.0.1:11434 \\
+          --output-dir ~/.nadirclaw/centroids/nomic
+
+    After building custom centroids, point the server at them::
+
+        NADIRCLAW_CENTROID_DIR=~/.nadirclaw/centroids/nomic \\
+        NADIRCLAW_EMBEDDING_BACKEND=ollama \\
+        NADIRCLAW_EMBEDDING_MODEL=nomic-embed-text \\
+        nadirclaw serve
+    """
+    import hashlib
     import logging
+    from datetime import datetime, timezone
 
     import numpy as np
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-    from nadirclaw.encoder import get_shared_encoder_sync
+    from nadirclaw.encoder import _build_encoder, _reset_shared_encoder
     from nadirclaw.prototypes import COMPLEX_PROTOTYPES, SIMPLE_PROTOTYPES
+    from nadirclaw.settings import settings
 
-    click.echo("Loading encoder...")
-    encoder = get_shared_encoder_sync()
+    backend = embedding_backend or settings.EMBEDDING_BACKEND
+    model_id = embedding_model or settings.EMBEDDING_MODEL
+    api_base = embedding_api_base or settings.EMBEDDING_API_BASE
+
+    # Ensure this command does not reuse an encoder built with prior settings.
+    _reset_shared_encoder()
+
+    click.echo(f"Loading encoder ({backend}/{model_id})...")
+    try:
+        encoder = _build_encoder(backend, model_id, api_base)
+    except (ValueError, RuntimeError) as exc:
+        raise click.ClickException(str(exc)) from exc
 
     click.echo(f"Encoding {len(SIMPLE_PROTOTYPES)} simple prototypes...")
     simple_embs = encoder.encode(SIMPLE_PROTOTYPES, show_progress_bar=False)
@@ -593,16 +649,44 @@ def build_centroids():
     complex_centroid = complex_embs.mean(axis=0)
     complex_centroid = complex_centroid / np.linalg.norm(complex_centroid)
 
-    pkg_dir = os.path.dirname(os.path.abspath(__file__))
-    simple_path = os.path.join(pkg_dir, "simple_centroid.npy")
-    complex_path = os.path.join(pkg_dir, "complex_centroid.npy")
+    dim = int(simple_centroid.shape[0])
 
-    np.save(simple_path, simple_centroid.astype(np.float32))
-    np.save(complex_path, complex_centroid.astype(np.float32))
+    # Determine output directory
+    if output_dir:
+        out_dir = Path(output_dir).expanduser()
+        out_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        out_dir = Path(os.path.dirname(os.path.abspath(__file__)))
+
+    simple_path = out_dir / "simple_centroid.npy"
+    complex_path = out_dir / "complex_centroid.npy"
+    meta_path = out_dir / "centroid_metadata.json"
+
+    np.save(str(simple_path), simple_centroid.astype(np.float32))
+    np.save(str(complex_path), complex_centroid.astype(np.float32))
+
+    # Prototype hash for traceability (short prefix for readability)
+    proto_content = "\n".join(sorted(SIMPLE_PROTOTYPES + COMPLEX_PROTOTYPES))
+    proto_hash = "sha256:" + hashlib.sha256(proto_content.encode()).hexdigest()[:16]
+
+    metadata = {
+        "schema_version": 1,
+        "embedding_backend": backend,
+        "embedding_model": model_id,
+        "dimension": dim,
+        "simple_count": len(SIMPLE_PROTOTYPES),
+        "complex_count": len(COMPLEX_PROTOTYPES),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "prototypes_hash": proto_hash,
+    }
+    meta_path.write_text(json.dumps(metadata, indent=2))
 
     click.echo(f"\nSaved: {simple_path}")
     click.echo(f"Saved: {complex_path}")
-    click.echo(f"Centroid dimension: {simple_centroid.shape[0]}")
+    click.echo(f"Saved: {meta_path}")
+    click.echo(f"Backend:   {backend}")
+    click.echo(f"Model:     {model_id}")
+    click.echo(f"Dimension: {dim}")
 
 
 @main.group()

--- a/nadirclaw/encoder.py
+++ b/nadirclaw/encoder.py
@@ -1,14 +1,29 @@
-"""Shared SentenceTransformer singleton for NadirClaw.
+"""Embedding encoder abstraction for NadirClaw.
+
+Supports multiple embedding backends:
+  - sentence-transformers (default, uses all-MiniLM-L6-v2)
+  - ollama (local Ollama server via /api/embed)
 
 The encoder is loaded lazily on first use — not at import time.
 This avoids the ~500ms cold-start penalty when running commands that
 don't need classification (e.g. ``nadirclaw serve`` before the first request).
+
+Backend and model are configured via:
+  NADIRCLAW_EMBEDDING_BACKEND=sentence-transformers|ollama
+  NADIRCLAW_EMBEDDING_MODEL=<model-id>
+  NADIRCLAW_EMBEDDING_API_BASE=<url>   (for ollama)
 """
 
+import json
 import logging
 import os
 import time
+import urllib.error
+import urllib.request
+from abc import ABC, abstractmethod
 from threading import Lock
+
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -16,28 +31,174 @@ _shared_encoder = None  # type: ignore[assignment]
 _encoder_lock = Lock()
 
 
-def get_shared_encoder_sync():
-    """
-    Lazily initialize and return a shared SentenceTransformer instance.
-    The first call loads the model (~80 MB download on first run).
-    Uses double-checked locking to avoid redundant loads.
+class BaseEmbeddingEncoder(ABC):
+    """Abstract base class for embedding encoders."""
 
-    The ``sentence_transformers`` import itself is deferred so that
-    ``import nadirclaw`` does not trigger a heavy torch import chain.
+    backend: str
+    model_id: str
+
+    @abstractmethod
+    def encode(
+        self,
+        texts: list[str],
+        show_progress_bar: bool = False,
+        normalize_embeddings: bool = False,
+    ) -> np.ndarray:
+        """Encode a list of texts into embedding vectors.
+
+        Returns a 2D ndarray of shape (len(texts), dimension).
+        """
+        ...
+
+    @property
+    def dimension(self) -> int | None:
+        """Embedding output dimension, or None if not yet determined."""
+        return None
+
+
+class SentenceTransformerEncoder(BaseEmbeddingEncoder):
+    """Encoder backed by the sentence-transformers library.
+
+    Default backend. On first use, downloads the model (~80 MB) if not cached.
+    Subsequent calls use the cached model. Warm encoding is ~10 ms/prompt.
+    """
+
+    backend = "sentence-transformers"
+
+    def __init__(self, model_id: str = "all-MiniLM-L6-v2") -> None:
+        self.model_id = model_id
+        # Suppress noisy tokenizer parallelism warning
+        os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+        t0 = time.time()
+        logger.info("Loading SentenceTransformer encoder: %s", model_id)
+        from sentence_transformers import SentenceTransformer
+        self._model = SentenceTransformer(model_id)
+        logger.info("SentenceTransformer encoder loaded (%dms)", int((time.time() - t0) * 1000))
+
+    def encode(
+        self,
+        texts: list[str],
+        show_progress_bar: bool = False,
+        normalize_embeddings: bool = False,
+    ) -> np.ndarray:
+        return self._model.encode(
+            texts,
+            show_progress_bar=show_progress_bar,
+            normalize_embeddings=normalize_embeddings,
+        )
+
+    @property
+    def dimension(self) -> int | None:
+        dim = self._model.get_sentence_embedding_dimension()
+        return int(dim) if dim is not None else None
+
+
+class OllamaEmbeddingEncoder(BaseEmbeddingEncoder):
+    """Encoder backed by a local Ollama server via its /api/embed endpoint.
+
+    Uses the batch-capable ``/api/embed`` API introduced in Ollama 0.1.26+.
+    Does not perform final inference — embeddings only.
+
+    Example usage::
+
+        NADIRCLAW_EMBEDDING_BACKEND=ollama
+        NADIRCLAW_EMBEDDING_MODEL=nomic-embed-text
+        NADIRCLAW_EMBEDDING_API_BASE=http://127.0.0.1:11434
+    """
+
+    backend = "ollama"
+
+    def __init__(self, model_id: str, api_base: str) -> None:
+        self.model_id = model_id
+        self._api_base = api_base.rstrip("/")
+        self._dim: int | None = None
+
+    def encode(
+        self,
+        texts: list[str],
+        show_progress_bar: bool = False,
+        normalize_embeddings: bool = False,
+    ) -> np.ndarray:
+        url = f"{self._api_base}/api/embed"
+        payload = json.dumps({"model": self.model_id, "input": texts}).encode()
+        req = urllib.request.Request(
+            url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                data = json.loads(resp.read())
+        except urllib.error.URLError as exc:
+            raise RuntimeError(
+                f"Ollama embedding request failed (url={self._api_base}): {exc}. "
+                f"Is Ollama running? Try: ollama serve"
+            ) from exc
+
+        embeddings = data.get("embeddings")
+        if not embeddings:
+            raise RuntimeError(
+                f"Ollama /api/embed returned no embeddings for model {self.model_id!r}. "
+                f"Is the model available? Run: ollama pull {self.model_id}"
+            )
+
+        arr = np.array(embeddings, dtype=np.float32)
+        if arr.ndim == 2:
+            self._dim = arr.shape[1]
+        if normalize_embeddings:
+            norms = np.linalg.norm(arr, axis=1, keepdims=True)
+            arr = arr / np.maximum(norms, 1e-12)
+        return arr
+
+    @property
+    def dimension(self) -> int | None:
+        """Dimension is known after the first encode() call."""
+        return self._dim
+
+
+def _build_encoder(backend: str, model_id: str, api_base: str) -> BaseEmbeddingEncoder:
+    """Factory: construct an encoder for the given backend.
+
+    Raises ValueError for unknown backend values.
+    """
+    if backend == "sentence-transformers":
+        return SentenceTransformerEncoder(model_id)
+    elif backend == "ollama":
+        return OllamaEmbeddingEncoder(model_id=model_id, api_base=api_base)
+    else:
+        raise ValueError(
+            f"Unknown embedding backend {backend!r}. "
+            f"Supported values: sentence-transformers, ollama. "
+            f"Set NADIRCLAW_EMBEDDING_BACKEND to one of these values."
+        )
+
+
+def get_shared_encoder_sync() -> BaseEmbeddingEncoder:
+    """Lazily initialize and return the shared encoder singleton.
+
+    Backend and model are read from settings:
+      NADIRCLAW_EMBEDDING_BACKEND  (default: sentence-transformers)
+      NADIRCLAW_EMBEDDING_MODEL    (default: all-MiniLM-L6-v2)
+      NADIRCLAW_EMBEDDING_API_BASE (default: OLLAMA_API_BASE)
+
+    Default behavior (sentence-transformers + all-MiniLM-L6-v2) is preserved
+    when no env vars are set. Uses double-checked locking to avoid redundant loads.
     """
     global _shared_encoder
     if _shared_encoder is None:
         with _encoder_lock:
             if _shared_encoder is None:
-                t0 = time.time()
-                logger.info("Loading SentenceTransformer encoder: all-MiniLM-L6-v2")
-
-                # Suppress noisy tokenizer parallelism warning
-                os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
-
-                from sentence_transformers import SentenceTransformer
-
-                _shared_encoder = SentenceTransformer("all-MiniLM-L6-v2")
-                elapsed = int((time.time() - t0) * 1000)
-                logger.info("SentenceTransformer encoder loaded (%dms)", elapsed)
+                from nadirclaw.settings import settings
+                backend = settings.EMBEDDING_BACKEND
+                model_id = settings.EMBEDDING_MODEL
+                api_base = settings.EMBEDDING_API_BASE
+                _shared_encoder = _build_encoder(backend, model_id, api_base)
     return _shared_encoder
+
+
+def _reset_shared_encoder() -> None:
+    """Reset the shared encoder singleton. For testing and CLI use only."""
+    global _shared_encoder
+    with _encoder_lock:
+        _shared_encoder = None

--- a/nadirclaw/settings.py
+++ b/nadirclaw/settings.py
@@ -295,5 +295,60 @@ class Settings:
         """Enable agent role detection for coding agents (opt-in)."""
         return os.getenv("NADIRCLAW_AGENT_ROLE_DETECTION", "false").lower() in ("true", "1", "yes")
 
+    # ------------------------------------------------------------------
+    # Embedding backend configuration
+    # ------------------------------------------------------------------
+
+    @property
+    def EMBEDDING_BACKEND(self) -> str:
+        """Embedding backend for the complexity classifier.
+
+        Supported values:
+          sentence-transformers  — local model via sentence-transformers library (default)
+          ollama                 — local Ollama server via /api/embed
+
+        Set via NADIRCLAW_EMBEDDING_BACKEND.
+        Default: sentence-transformers
+        """
+        return os.getenv("NADIRCLAW_EMBEDDING_BACKEND", "sentence-transformers")
+
+    @property
+    def EMBEDDING_MODEL(self) -> str:
+        """Embedding model ID used by the classifier.
+
+        For sentence-transformers: any HuggingFace model ID.
+        For ollama: the model name to pass to /api/embed.
+
+        Set via NADIRCLAW_EMBEDDING_MODEL.
+        Default: all-MiniLM-L6-v2
+        """
+        return os.getenv("NADIRCLAW_EMBEDDING_MODEL", "all-MiniLM-L6-v2")
+
+    @property
+    def EMBEDDING_API_BASE(self) -> str:
+        """Base URL for the embedding API endpoint (used by the ollama backend).
+
+        Set via NADIRCLAW_EMBEDDING_API_BASE.
+        Default: same as OLLAMA_API_BASE (http://localhost:11434)
+        """
+        return os.getenv("NADIRCLAW_EMBEDDING_API_BASE", self.OLLAMA_API_BASE)
+
+    @property
+    def CENTROID_DIR(self) -> "Path | None":
+        """Custom directory for centroid .npy and metadata files.
+
+        When set, the classifier loads centroids from this directory and
+        requires a centroid_metadata.json file for safety validation.
+        When unset (default), the package directory is used and metadata
+        is optional for backward compatibility.
+
+        Set via NADIRCLAW_CENTROID_DIR.
+        Default: None (use package directory)
+        """
+        val = os.getenv("NADIRCLAW_CENTROID_DIR", "")
+        if val:
+            return Path(val).expanduser()
+        return None
+
 
 settings = Settings()

--- a/tests/test_embedding_config.py
+++ b/tests/test_embedding_config.py
@@ -1,0 +1,485 @@
+"""Tests for configurable embedding backend/model support.
+
+Covers:
+  - Default settings preserve sentence-transformers + all-MiniLM-L6-v2
+  - Unknown embedding backend raises a clear error
+  - Centroid metadata matching model/backend loads successfully
+  - Centroid metadata backend mismatch fails closed
+  - Centroid metadata model mismatch fails closed
+  - Centroid dimension mismatch fails closed
+  - Missing metadata in custom centroid dir fails closed
+  - build-centroids writes .npy files and centroid_metadata.json
+  - OllamaEmbeddingEncoder calls /api/embed and returns ndarray
+
+Ollama HTTP is mocked throughout — no live Ollama required.
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DIM = 16  # small fake embedding dimension for fast tests
+
+
+def _fake_centroids(dim: int = _DIM):
+    """Return normalized (simple, complex) centroid ndarrays."""
+    rng = np.random.default_rng(42)
+    s = rng.random(dim).astype(np.float32)
+    c = rng.random(dim).astype(np.float32)
+    return s / np.linalg.norm(s), c / np.linalg.norm(c)
+
+
+def _write_centroids(directory: Path, dim: int = _DIM, metadata: dict | None = None):
+    """Write simple/complex .npy files and optional centroid_metadata.json."""
+    s, c = _fake_centroids(dim)
+    np.save(str(directory / "simple_centroid.npy"), s)
+    np.save(str(directory / "complex_centroid.npy"), c)
+    if metadata is not None:
+        (directory / "centroid_metadata.json").write_text(json.dumps(metadata))
+
+
+def _default_meta(
+    backend="sentence-transformers",
+    model="all-MiniLM-L6-v2",
+    dim=_DIM,
+) -> dict:
+    return {
+        "schema_version": 1,
+        "embedding_backend": backend,
+        "embedding_model": model,
+        "dimension": dim,
+        "simple_count": 5,
+        "complex_count": 5,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "prototypes_hash": "sha256:abc123",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Settings tests
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingSettings:
+    def test_default_backend(self, monkeypatch):
+        monkeypatch.delenv("NADIRCLAW_EMBEDDING_BACKEND", raising=False)
+        from nadirclaw.settings import Settings
+        s = Settings()
+        assert s.EMBEDDING_BACKEND == "sentence-transformers"
+
+    def test_default_model(self, monkeypatch):
+        monkeypatch.delenv("NADIRCLAW_EMBEDDING_MODEL", raising=False)
+        from nadirclaw.settings import Settings
+        s = Settings()
+        assert s.EMBEDDING_MODEL == "all-MiniLM-L6-v2"
+
+    def test_default_centroid_dir_is_none(self, monkeypatch):
+        monkeypatch.delenv("NADIRCLAW_CENTROID_DIR", raising=False)
+        from nadirclaw.settings import Settings
+        s = Settings()
+        assert s.CENTROID_DIR is None
+
+    def test_custom_backend_via_env(self, monkeypatch):
+        monkeypatch.setenv("NADIRCLAW_EMBEDDING_BACKEND", "ollama")
+        from nadirclaw.settings import Settings
+        assert Settings().EMBEDDING_BACKEND == "ollama"
+
+    def test_custom_model_via_env(self, monkeypatch):
+        monkeypatch.setenv("NADIRCLAW_EMBEDDING_MODEL", "nomic-embed-text")
+        from nadirclaw.settings import Settings
+        assert Settings().EMBEDDING_MODEL == "nomic-embed-text"
+
+    def test_centroid_dir_via_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("NADIRCLAW_CENTROID_DIR", str(tmp_path))
+        from nadirclaw.settings import Settings
+        assert Settings().CENTROID_DIR == tmp_path
+
+    def test_embedding_api_base_defaults_to_ollama_api_base(self, monkeypatch):
+        monkeypatch.delenv("NADIRCLAW_EMBEDDING_API_BASE", raising=False)
+        monkeypatch.setenv("OLLAMA_API_BASE", "http://myhost:11434")
+        from nadirclaw.settings import Settings
+        assert Settings().EMBEDDING_API_BASE == "http://myhost:11434"
+
+    def test_embedding_api_base_override(self, monkeypatch):
+        monkeypatch.setenv("NADIRCLAW_EMBEDDING_API_BASE", "http://custom:9999")
+        from nadirclaw.settings import Settings
+        assert Settings().EMBEDDING_API_BASE == "http://custom:9999"
+
+
+# ---------------------------------------------------------------------------
+# Encoder factory tests
+# ---------------------------------------------------------------------------
+
+
+class TestEncoderFactory:
+    def test_unknown_backend_raises_value_error(self):
+        from nadirclaw.encoder import _build_encoder
+        with pytest.raises(ValueError, match="Unknown embedding backend"):
+            _build_encoder("bogus-backend", "any-model", "http://localhost:11434")
+
+    def test_sentence_transformers_backend_key(self):
+        from nadirclaw.encoder import SentenceTransformerEncoder
+        assert SentenceTransformerEncoder.backend == "sentence-transformers"
+
+    def test_ollama_backend_key(self):
+        from nadirclaw.encoder import OllamaEmbeddingEncoder
+        assert OllamaEmbeddingEncoder.backend == "ollama"
+
+    def test_build_encoder_returns_sentence_transformer(self):
+        """_build_encoder with sentence-transformers should return the right type."""
+        from nadirclaw.encoder import SentenceTransformerEncoder, _build_encoder
+
+        mock_st = MagicMock()
+        mock_st.encode.return_value = np.zeros((_DIM,), dtype=np.float32)
+
+        with patch("nadirclaw.encoder.SentenceTransformerEncoder.__init__", return_value=None):
+            enc = _build_encoder("sentence-transformers", "all-MiniLM-L6-v2", "")
+            assert isinstance(enc, SentenceTransformerEncoder)
+
+    def test_build_encoder_returns_ollama(self):
+        from nadirclaw.encoder import OllamaEmbeddingEncoder, _build_encoder
+        enc = _build_encoder("ollama", "nomic-embed-text", "http://localhost:11434")
+        assert isinstance(enc, OllamaEmbeddingEncoder)
+        assert enc.model_id == "nomic-embed-text"
+
+    def test_reset_shared_encoder(self, monkeypatch):
+        """_reset_shared_encoder should clear the singleton."""
+        from nadirclaw import encoder as enc_mod
+        enc_mod._shared_encoder = MagicMock()  # set a fake singleton
+        from nadirclaw.encoder import _reset_shared_encoder
+        _reset_shared_encoder()
+        assert enc_mod._shared_encoder is None
+
+
+# ---------------------------------------------------------------------------
+# OllamaEmbeddingEncoder HTTP mocking tests
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaEncoder:
+    def _make_response(self, embeddings: list[list[float]]) -> bytes:
+        return json.dumps({"embeddings": embeddings}).encode()
+
+    def test_encode_returns_ndarray(self):
+        from nadirclaw.encoder import OllamaEmbeddingEncoder
+
+        enc = OllamaEmbeddingEncoder("nomic-embed-text", "http://localhost:11434")
+        fake_embs = [[0.1] * _DIM, [0.2] * _DIM]
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = self._make_response(fake_embs)
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_resp
+
+            result = enc.encode(["hello", "world"])
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2, _DIM)
+
+    def test_encode_sets_dimension(self):
+        from nadirclaw.encoder import OllamaEmbeddingEncoder
+
+        enc = OllamaEmbeddingEncoder("nomic-embed-text", "http://localhost:11434")
+        assert enc.dimension is None  # unknown before first encode
+
+        fake_embs = [[0.1] * _DIM]
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = self._make_response(fake_embs)
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_resp
+            enc.encode(["hello"])
+
+        assert enc.dimension == _DIM
+
+    def test_encode_raises_on_connection_error(self):
+        import urllib.error
+
+        from nadirclaw.encoder import OllamaEmbeddingEncoder
+
+        enc = OllamaEmbeddingEncoder("nomic-embed-text", "http://localhost:11434")
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("refused")):
+            with pytest.raises(RuntimeError, match="Ollama embedding request failed"):
+                enc.encode(["hello"])
+
+    def test_encode_raises_on_empty_embeddings(self):
+        from nadirclaw.encoder import OllamaEmbeddingEncoder
+
+        enc = OllamaEmbeddingEncoder("nomic-embed-text", "http://localhost:11434")
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps({"embeddings": []}).encode()
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_resp
+            with pytest.raises(RuntimeError, match="no embeddings"):
+                enc.encode(["hello"])
+
+
+# ---------------------------------------------------------------------------
+# Centroid loading and validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestCentroidLoading:
+    """Tests for BinaryComplexityClassifier._load_centroids metadata validation."""
+
+    def _make_settings(self, monkeypatch, backend="sentence-transformers",
+                       model="all-MiniLM-L6-v2", centroid_dir=None):
+        monkeypatch.setenv("NADIRCLAW_EMBEDDING_BACKEND", backend)
+        monkeypatch.setenv("NADIRCLAW_EMBEDDING_MODEL", model)
+        if centroid_dir is not None:
+            monkeypatch.setenv("NADIRCLAW_CENTROID_DIR", str(centroid_dir))
+        else:
+            monkeypatch.delenv("NADIRCLAW_CENTROID_DIR", raising=False)
+        from nadirclaw.settings import Settings
+        return Settings()
+
+    def test_load_centroids_with_matching_metadata(self, monkeypatch, tmp_path):
+        """Centroids + matching metadata should load without error."""
+        meta = _default_meta()
+        _write_centroids(tmp_path, dim=_DIM, metadata=meta)
+        settings = self._make_settings(monkeypatch, centroid_dir=tmp_path)
+
+        from nadirclaw.classifier import BinaryComplexityClassifier
+
+        simple, complex_ = BinaryComplexityClassifier._load_centroids(
+            encoder=None, settings=settings
+        )
+        assert simple.shape == (_DIM,)
+        assert complex_.shape == (_DIM,)
+
+    def test_load_centroids_backend_mismatch_raises(self, monkeypatch, tmp_path):
+        """Centroids built for ollama but current backend is sentence-transformers → fail."""
+        meta = _default_meta(backend="ollama", model="nomic-embed-text", dim=_DIM)
+        _write_centroids(tmp_path, dim=_DIM, metadata=meta)
+        settings = self._make_settings(
+            monkeypatch,
+            backend="sentence-transformers",
+            model="all-MiniLM-L6-v2",
+            centroid_dir=tmp_path,
+        )
+
+        from nadirclaw.classifier import BinaryComplexityClassifier
+
+        with pytest.raises(RuntimeError, match="backend"):
+            BinaryComplexityClassifier._load_centroids(encoder=None, settings=settings)
+
+    def test_load_centroids_model_mismatch_raises(self, monkeypatch, tmp_path):
+        """Centroids for nomic-embed-text but current model is all-MiniLM → fail."""
+        meta = _default_meta(
+            backend="sentence-transformers", model="nomic-embed-text", dim=_DIM
+        )
+        _write_centroids(tmp_path, dim=_DIM, metadata=meta)
+        settings = self._make_settings(
+            monkeypatch,
+            backend="sentence-transformers",
+            model="all-MiniLM-L6-v2",
+            centroid_dir=tmp_path,
+        )
+
+        from nadirclaw.classifier import BinaryComplexityClassifier
+
+        with pytest.raises(RuntimeError, match="model"):
+            BinaryComplexityClassifier._load_centroids(encoder=None, settings=settings)
+
+    def test_load_centroids_dimension_mismatch_in_metadata_raises(self, monkeypatch, tmp_path):
+        """Metadata dimension != actual centroid file dimension → fail."""
+        meta = _default_meta(dim=999)  # wrong dimension in metadata
+        _write_centroids(tmp_path, dim=_DIM, metadata=meta)  # actual dim = _DIM
+        settings = self._make_settings(monkeypatch, centroid_dir=tmp_path)
+
+        from nadirclaw.classifier import BinaryComplexityClassifier
+
+        with pytest.raises(RuntimeError, match="dimension"):
+            BinaryComplexityClassifier._load_centroids(encoder=None, settings=settings)
+
+    def test_load_centroids_simple_complex_shape_mismatch_raises(self, monkeypatch, tmp_path):
+        """simple_centroid and complex_centroid of different shapes → fail."""
+        rng = np.random.default_rng(1)
+        np.save(str(tmp_path / "simple_centroid.npy"), rng.random(8).astype(np.float32))
+        np.save(str(tmp_path / "complex_centroid.npy"), rng.random(16).astype(np.float32))
+        settings = self._make_settings(monkeypatch, centroid_dir=tmp_path)
+
+        from nadirclaw.classifier import BinaryComplexityClassifier
+
+        with pytest.raises(ValueError, match="dimension mismatch"):
+            BinaryComplexityClassifier._load_centroids(encoder=None, settings=settings)
+
+    def test_missing_metadata_in_custom_dir_raises(self, monkeypatch, tmp_path):
+        """Custom CENTROID_DIR without metadata file should fail closed."""
+        # Write centroids but NO metadata
+        _write_centroids(tmp_path, dim=_DIM, metadata=None)
+        settings = self._make_settings(monkeypatch, centroid_dir=tmp_path)
+
+        from nadirclaw.classifier import BinaryComplexityClassifier
+
+        with pytest.raises(FileNotFoundError, match="centroid_metadata.json"):
+            BinaryComplexityClassifier._load_centroids(encoder=None, settings=settings)
+
+    def test_missing_centroids_in_custom_dir_raises(self, monkeypatch, tmp_path):
+        """Custom CENTROID_DIR with no .npy files → clear error."""
+        settings = self._make_settings(monkeypatch, centroid_dir=tmp_path)
+
+        from nadirclaw.classifier import BinaryComplexityClassifier
+
+        with pytest.raises(FileNotFoundError):
+            BinaryComplexityClassifier._load_centroids(encoder=None, settings=settings)
+
+    def test_encoder_dimension_mismatch_raises(self, monkeypatch, tmp_path):
+        """Encoder dimension != centroid dimension → fail."""
+        meta = _default_meta(dim=_DIM)
+        _write_centroids(tmp_path, dim=_DIM, metadata=meta)
+        settings = self._make_settings(monkeypatch, centroid_dir=tmp_path)
+
+        # Mock an encoder that says dimension = 999
+        mock_encoder = MagicMock()
+        mock_encoder.dimension = 999
+
+        from nadirclaw.classifier import BinaryComplexityClassifier
+
+        with pytest.raises(RuntimeError, match="Encoder output dimension"):
+            BinaryComplexityClassifier._load_centroids(
+                encoder=mock_encoder, settings=settings
+            )
+
+    def test_default_pkg_dir_no_metadata_loads_ok(self, monkeypatch):
+        """Package directory without metadata should load silently (backward compat)."""
+        monkeypatch.delenv("NADIRCLAW_CENTROID_DIR", raising=False)
+        monkeypatch.setenv("NADIRCLAW_EMBEDDING_BACKEND", "sentence-transformers")
+        monkeypatch.setenv("NADIRCLAW_EMBEDDING_MODEL", "all-MiniLM-L6-v2")
+        from nadirclaw.settings import Settings
+        settings = Settings()
+
+        # The package .npy files are present; this should not raise even if no metadata
+        from nadirclaw.classifier import BinaryComplexityClassifier
+
+        simple, complex_ = BinaryComplexityClassifier._load_centroids(
+            encoder=None, settings=settings
+        )
+        assert simple.ndim == 1
+        assert complex_.ndim == 1
+        assert simple.shape == complex_.shape
+
+
+# ---------------------------------------------------------------------------
+# build-centroids CLI tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCentroidsCLI:
+    """Tests for the build-centroids CLI command."""
+
+    def test_build_centroids_default_writes_npy_and_metadata(self, tmp_path, monkeypatch):
+        """build-centroids should write simple/complex .npy and centroid_metadata.json."""
+        from click.testing import CliRunner
+
+        from nadirclaw.cli import main
+
+        monkeypatch.delenv("NADIRCLAW_EMBEDDING_BACKEND", raising=False)
+        monkeypatch.delenv("NADIRCLAW_EMBEDDING_MODEL", raising=False)
+
+        fake_embs = np.random.default_rng(0).random((5, _DIM)).astype(np.float32)
+
+        with patch("nadirclaw.encoder.SentenceTransformerEncoder.__init__", return_value=None):
+            with patch(
+                "nadirclaw.encoder.SentenceTransformerEncoder.encode",
+                return_value=fake_embs,
+            ):
+                with patch(
+                    "nadirclaw.encoder.SentenceTransformerEncoder.dimension",
+                    new_callable=lambda: property(lambda self: _DIM),
+                ):
+                    from nadirclaw.encoder import _reset_shared_encoder
+                    _reset_shared_encoder()
+
+                    runner = CliRunner()
+                    result = runner.invoke(
+                        main,
+                        ["build-centroids", "--output-dir", str(tmp_path)],
+                        catch_exceptions=False,
+                    )
+
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "simple_centroid.npy").exists()
+        assert (tmp_path / "complex_centroid.npy").exists()
+        assert (tmp_path / "centroid_metadata.json").exists()
+
+        meta = json.loads((tmp_path / "centroid_metadata.json").read_text())
+        assert meta["schema_version"] == 1
+        assert meta["embedding_backend"] == "sentence-transformers"
+        assert meta["embedding_model"] == "all-MiniLM-L6-v2"
+        assert meta["dimension"] == _DIM
+        assert "created_at" in meta
+        assert "prototypes_hash" in meta
+
+    def test_build_centroids_custom_backend_flags(self, tmp_path, monkeypatch):
+        """CLI flags should override backend/model in written metadata."""
+        from click.testing import CliRunner
+
+        from nadirclaw.cli import main
+
+        fake_embs = np.random.default_rng(1).random((5, 768)).astype(np.float32)
+        fake_response = json.dumps(
+            {"embeddings": fake_embs.tolist()}
+        ).encode()
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = fake_response
+            mock_resp.__enter__ = lambda s: s
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_resp
+
+            from nadirclaw.encoder import _reset_shared_encoder
+            _reset_shared_encoder()
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "build-centroids",
+                    "--embedding-backend", "ollama",
+                    "--embedding-model", "nomic-embed-text",
+                    "--embedding-api-base", "http://127.0.0.1:11434",
+                    "--output-dir", str(tmp_path),
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        meta = json.loads((tmp_path / "centroid_metadata.json").read_text())
+        assert meta["embedding_backend"] == "ollama"
+        assert meta["embedding_model"] == "nomic-embed-text"
+        assert meta["dimension"] == 768
+
+    def test_build_centroids_unknown_backend_fails(self, tmp_path, monkeypatch):
+        """build-centroids with an unsupported backend should exit non-zero."""
+        from click.testing import CliRunner
+
+        from nadirclaw.cli import main
+        from nadirclaw.encoder import _reset_shared_encoder
+        _reset_shared_encoder()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "build-centroids",
+                "--embedding-backend", "not-a-real-backend",
+                "--output-dir", str(tmp_path),
+            ],
+        )
+        assert result.exit_code != 0


### PR DESCRIPTION
## Summary
- add configurable embedding backend/model settings for classifier routing
- support sentence-transformers (default) and Ollama /api/embed embeddings without changing the default model
- add centroid metadata generation/validation and custom centroid directory support
- extend build-centroids CLI with backend/model/api-base/output-dir flags

## Tests
- python -m pytest tests/test_embedding_config.py -q
- python -m pytest tests/test_classifier.py tests/test_routing.py tests/test_embedding_config.py -q
- python -m pytest -q

## Scope
PR #1 only: configurable embedding backend/model + centroid metadata validation. Reasoning-route work is intentionally deferred.