### PR TITLE
chore: move DistilBERT model to nadirclaw HF org namespace

### DIFF
--- a/nadirclaw/distilbert_classifier.py
+++ b/nadirclaw/distilbert_classifier.py
@@ -22,7 +22,7 @@ _PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 _MODEL_DIR = os.path.join(_PKG_DIR, "distilbert_model")
 # Published artifact (~256MB). from_pretrained() downloads + caches it under
 # ~/.cache/huggingface/hub on first use. Override with NADIRCLAW_DISTILBERT_REPO.
-_HF_REPO = os.getenv("NADIRCLAW_DISTILBERT_REPO", "amirdor/nadirclaw-distilbert")
+_HF_REPO = os.getenv("NADIRCLAW_DISTILBERT_REPO", "nadirclaw/nadirclaw-distilbert")
 _TIER_MAP = {0: "simple", 1: "medium", 2: "complex"}
 
 


### PR DESCRIPTION
## Summary

Follow-up to #51. The DistilBERT complexity classifier artifact was published under a personal Hugging Face account (`amirdor/nadirclaw-distilbert`). This moves it to the project org (`nadirclaw/nadirclaw-distilbert`) so it isn't tied to one person's account and co-maintainers can push retrained versions.

## Changes

- HF repo transferred: `amirdor/nadirclaw-distilbert` → [`nadirclaw/nadirclaw-distilbert`](https://huggingface.co/nadirclaw/nadirclaw-distilbert) (the old path 301-redirects, so existing `~/.cache/huggingface` caches keep working).
- Model card updated on the Hub to reference the new path.
- `_HF_REPO` default in `nadirclaw/distilbert_classifier.py` updated to match. `NADIRCLAW_DISTILBERT_REPO` still overrides it.

## Impact

- Opt-in feature (`NADIRCLAW_COMPLEXITY_ANALYZER=distilbert`), default `binary` unaffected.
- Graceful fallback to binary on any load failure is unchanged.
- One-line code change; no behavior change for existing users.

## Test plan

- [x] `from_pretrained("nadirclaw/nadirclaw-distilbert")` loads (3-class, verified)
- [x] grep confirms no remaining `amirdor/` references in code or docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)