### PR TITLE
feat(marketing): Pro upsells in CLI + README funnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@
 </p>
 
 <p align="center">
-  <a href="https://getnadir.com">Website</a> · <a href="#quick-start">Quick Start</a> · <a href="docs/comparison.md">Comparisons</a> · <a href="https://github.com/doramirdor/nadirclaw-action">GitHub Action</a>
+  <a href="https://getnadir.com?ref=readme-nav"><strong>Nadir Pro (hosted)</strong></a> · <a href="#quick-start">Quick Start</a> · <a href="#nadirclaw-vs-nadir-pro">OSS vs Pro</a> · <a href="docs/comparison.md">Comparisons</a> · <a href="https://github.com/doramirdor/nadirclaw-action">GitHub Action</a>
+</p>
+
+<p align="center">
+  <sub>Running real traffic or a team? <a href="https://getnadir.com?ref=readme-hero">Nadir Pro</a> adds a trained classifier (10-20% more savings), a live dashboard, team billing, and SSO. <strong>30-day free trial.</strong></sub>
 </p>
 
 ---
@@ -80,6 +84,25 @@ nadirclaw serve --verbose
 ```
 
 That's it. NadirClaw starts on `http://localhost:8856` with sensible defaults (Gemini 3 Flash for simple, OpenAI Codex for complex). If you skip `nadirclaw setup`, the `serve` command will offer to run it on first launch.
+
+## NadirClaw vs Nadir Pro
+
+NadirClaw is the free, open-source core. If you are routing production traffic or running a team, [**Nadir Pro**](https://getnadir.com) is the hosted version with more accurate routing, team features, and analytics. Same routing philosophy, zero vendor lock-in (Pro lets you BYOK and you can always fall back to NadirClaw self-hosted).
+
+|  | NadirClaw (Free, OSS) | [Nadir Pro](https://getnadir.com) (Hosted) |
+|---|---|---|
+| **License** | MIT | Proprietary |
+| **Deploy** | Self-hosted, localhost | `api.getnadir.com` or self-host via Docker |
+| **Classifier** | Binary centroid, ~10ms | Trained classifier + 3-tier routing, higher accuracy |
+| **Storage** | Local JSONL + SQLite | Postgres (Supabase), multi-tenant |
+| **Dashboard** | Terminal + local web | Hosted web dashboard, per-team analytics |
+| **Cost tracking** | `nadirclaw savings` CLI | Live dashboard, monthly invoices, projected savings |
+| **Extras** | Context optimize, fallback chains | Everything in Free, plus semantic cache, response healing, prompt caching passthrough |
+| **Team** | None | SSO, audit logs, API key management, priority support |
+| **Billing** | N/A | Pay only on savings: 25% of first $2K, 10% above, plus $9/mo base |
+| **Best for** | Solo devs, self-hosters, anyone who wants the router running locally | Teams routing real traffic who want a hosted dashboard and want someone else to maintain the classifier |
+
+**Start free at [getnadir.com](https://getnadir.com/auth?mode=signup)** (15 requests/day on our keys, unlimited with BYOK). If Nadir is not saving you money, you do not pay us.
 
 ## Features
 

--- a/demo/cost_vs_opus.py
+++ b/demo/cost_vs_opus.py
@@ -1,0 +1,170 @@
+"""
+Demo: show Nadir routing in action, comparing per-prompt cost vs always-Opus.
+
+Designed for screen recording. Runs in ~5 seconds, no API keys needed
+(uses `nadirclaw classify` which is local, embedding-only).
+
+Usage:
+    pip install nadirclaw
+    python demo/cost_vs_opus.py
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+from rich.console import Console
+from rich.table import Table
+from rich.text import Text
+
+
+PROMPTS = [
+    "What is 2+2?",
+    "Format this JSON: {'name':'alice','age':30,'roles':['admin','user']}",
+    "Add a one-line docstring to this function",
+    "Write a Python function that deduplicates a list of dicts by key",
+    "Refactor this auth module to use dependency injection and add unit tests",
+    "Design a distributed system for real-time trading with exactly-once semantics",
+]
+
+DEMO_ENV = {
+    "NADIRCLAW_SIMPLE_MODEL": "haiku",
+    "NADIRCLAW_MID_MODEL": "sonnet",
+    "NADIRCLAW_COMPLEX_MODEL": "opus",
+    "NADIRCLAW_TIER_THRESHOLDS": "0.35,0.65",
+}
+
+ALIASES = {
+    "opus": "claude-opus-4-6",
+    "sonnet": "claude-sonnet-4-6",
+    "haiku": "claude-haiku-4-5",
+    "flash": "gemini-2.5-flash",
+    "gemini-pro": "gemini-2.5-pro",
+    "gpt4": "gpt-4.1",
+    "gpt5": "gpt-5.2",
+}
+
+PRICING_PER_M = {
+    "claude-opus-4-6": (15.0, 75.0),
+    "claude-opus-4-7": (15.0, 75.0),
+    "claude-sonnet-4-5": (3.0, 15.0),
+    "claude-sonnet-4-6": (3.0, 15.0),
+    "claude-haiku-4-5": (1.0, 5.0),
+    "gemini-2.5-pro": (1.25, 10.0),
+    "gemini-2.5-flash": (0.30, 2.50),
+    "gemini-3-flash-preview": (0.30, 2.50),
+    "gpt-4.1": (2.0, 8.0),
+    "gpt-4.1-mini": (0.40, 1.60),
+    "gpt-5.2": (5.0, 15.0),
+    "openai-codex/gpt-5.3-codex": (5.0, 15.0),
+}
+BENCHMARK_MODEL = "claude-opus-4-6"
+ASSUMED_OUTPUT_TOKENS = 180
+
+
+def resolve_model(model: str) -> str:
+    if model in ALIASES:
+        return ALIASES[model]
+    return model
+
+
+def price_for(model: str) -> tuple[float, float]:
+    model = resolve_model(model)
+    if model in PRICING_PER_M:
+        return PRICING_PER_M[model]
+    for key, val in PRICING_PER_M.items():
+        if model.startswith(key) or key.startswith(model):
+            return val
+    return PRICING_PER_M[BENCHMARK_MODEL]
+
+
+def cost_usd(model: str, input_tokens: int, output_tokens: int) -> float:
+    p_in, p_out = price_for(model)
+    return (input_tokens * p_in + output_tokens * p_out) / 1_000_000
+
+
+def classify(prompt: str) -> dict:
+    env = {**os.environ, **DEMO_ENV}
+    raw = subprocess.check_output(
+        ["nadirclaw", "classify", "--format", "json", prompt],
+        text=True,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+    return json.loads(raw)
+
+
+def estimate_input_tokens(prompt: str) -> int:
+    return max(8, int(len(prompt.split()) * 1.3))
+
+
+def main() -> int:
+    console = Console()
+
+    if shutil.which("nadirclaw") is None:
+        console.print("[red]nadirclaw is not on PATH. Run: pip install nadirclaw[/red]")
+        return 1
+
+    console.print()
+    console.print(Text("Nadir routing demo", style="bold cyan"))
+    console.print(
+        Text(
+            f"Benchmark: always route everything to {BENCHMARK_MODEL}.\n"
+            f"Compare: Nadir routes each prompt to the right tier.",
+            style="dim",
+        )
+    )
+    console.print()
+
+    table = Table(show_lines=False, header_style="bold")
+    table.add_column("Prompt", max_width=52, overflow="fold")
+    table.add_column("Tier", style="cyan")
+    table.add_column("Routed to", style="green")
+    table.add_column("Nadir cost", justify="right")
+    table.add_column("Opus-only", justify="right", style="dim")
+
+    total_nadir = 0.0
+    total_opus = 0.0
+
+    for prompt in PROMPTS:
+        result = classify(prompt)
+        routed_model = result.get("model", "unknown")
+        tier = result.get("tier", "?")
+        in_tok = estimate_input_tokens(prompt)
+        n_cost = cost_usd(routed_model, in_tok, ASSUMED_OUTPUT_TOKENS)
+        o_cost = cost_usd(BENCHMARK_MODEL, in_tok, ASSUMED_OUTPUT_TOKENS)
+        total_nadir += n_cost
+        total_opus += o_cost
+        table.add_row(
+            prompt,
+            tier,
+            routed_model,
+            f"${n_cost:.5f}",
+            f"${o_cost:.5f}",
+        )
+
+    table.add_section()
+    saved = total_opus - total_nadir
+    pct = (saved / total_opus) * 100 if total_opus else 0
+    table.add_row(
+        Text(f"Total across {len(PROMPTS)} prompts", style="bold"),
+        "",
+        "",
+        Text(f"${total_nadir:.4f}", style="bold green"),
+        Text(f"${total_opus:.4f}", style="bold dim"),
+    )
+
+    console.print(table)
+    console.print()
+    console.print(
+        f"[bold green]Saved ${saved:.4f} ({pct:.0f}%) vs always-Opus.[/bold green] "
+        f"[dim]Extrapolated to 10k requests/day: ~${saved * 2000:.0f}/mo.[/dim]"
+    )
+    console.print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nadirclaw/report.py
+++ b/nadirclaw/report.py
@@ -324,6 +324,17 @@ def format_report_text(report: Dict[str, Any]) -> str:
         for line in extras:
             lines.append(f"  {line}")
 
+    # Pro upsell at report-generation time, when the user has just seen their
+    # cost number. Only shown if there is meaningful cost to upsell against.
+    total_cost = report.get("total_cost", 0) or 0
+    if total_cost > 0.50:
+        lines.append("")
+        lines.append("=" * 50)
+        lines.append("This report updates in real time on Nadir Pro, with per-team")
+        lines.append("breakdowns, alerting, and a trained classifier that cuts costs")
+        lines.append("another 10-20% on the same traffic.")
+        lines.append("30-day free trial: https://getnadir.com?ref=cli-report")
+
     lines.append("")
     return "\n".join(lines)
 

--- a/nadirclaw/savings.py
+++ b/nadirclaw/savings.py
@@ -181,6 +181,9 @@ def format_savings_text(report: Dict[str, Any]) -> str:
 
     if report.get("total_requests", 0) == 0:
         lines.append("No requests found. Start using NadirClaw to see savings!")
+        lines.append("")
+        lines.append("Tip: Nadir Pro tracks savings in a live dashboard, no CLI needed.")
+        lines.append("     https://getnadir.com?ref=cli-savings")
         return "\n".join(lines)
 
     lines.append(f"Total requests:  {report['total_requests']}")
@@ -228,6 +231,21 @@ def format_savings_text(report: Dict[str, Any]) -> str:
         lines.append(f"  Without NadirClaw:  ${proj['monthly_baseline']:.2f}/mo")
         lines.append(f"  With NadirClaw:     ${proj['monthly_actual']:.2f}/mo")
         lines.append(f"  Monthly savings:    ${proj['monthly_savings']:.2f}/mo")
+
+    # Pro upsell at the moment of highest intent: when the user has just
+    # seen their own savings number. Only shown if savings are positive.
+    savings_value = report.get("savings", 0) or 0
+    if savings_value > 0:
+        monthly = (proj or {}).get("monthly_savings", 0) or 0
+        lines.append("")
+        lines.append("=" * 50)
+        lines.append("Nadir Pro: trained classifier finds 10-20% more savings on the")
+        lines.append("same traffic, plus a live dashboard and team analytics.")
+        if monthly > 0:
+            lines.append(
+                f"At your current run rate, that is ~${monthly * 0.15:.2f}-${monthly * 0.20:.2f}/mo extra."
+            )
+        lines.append("Start the 30-day Pro trial: https://getnadir.com?ref=cli-savings")
 
     lines.append("")
     return "\n".join(lines)

--- a/nadirclaw/server.py
+++ b/nadirclaw/server.py
@@ -367,6 +367,9 @@ async def startup():
         logger.warning("LiteLLM setup issue: %s", e)
 
     logger.info("Ready! Listening for requests...")
+    logger.info("")
+    logger.info("Want a hosted dashboard, trained classifier, and team billing?")
+    logger.info("Try Nadir Pro free: https://getnadir.com?ref=cli-serve")
     logger.info("=" * 60)
 
 


### PR DESCRIPTION
## Summary

Surfaces Nadir Pro at three high-intent moments so the OSS router doubles as the Pro funnel.

- **README** — new top-nav "Nadir Pro (hosted)" link + hero sub-callout, plus a full OSS-vs-Pro comparison section after Quick Start
- **`nadirclaw savings`** — personalized upsell footer showing projected extra monthly savings from Pro's trained classifier
- **`nadirclaw serve`** — startup banner ends with a Pro CTA
- **`nadirclaw report`** — footer plugs Pro when total cost > \$0.50

All upsell URLs carry `?ref=cli-savings|cli-serve|cli-report|readme-*` tags so the site's attribution layer can break down signups by surface.

Also adds `demo/cost_vs_opus.py` — a zero-API-key screen-record demo that classifies 6 prompts and prints Nadir routing cost vs always-Opus.

## Files

- `README.md` — nav link, hero callout, OSS-vs-Pro section
- `nadirclaw/savings.py` / `nadirclaw/report.py` / `nadirclaw/server.py` — CLI upsell surfaces
- `demo/cost_vs_opus.py` — new demo script

🤖 Generated with [Claude Code](https://claude.com/claude-code)