### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to NadirClaw will be documented in this file.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-05-14
+
+### Added
+- **Anthropic-compatible `/v1/messages` endpoint** — Anthropic-native clients (Claude Code) now route through NadirClaw. The proxy classifies, rewrites the `model` field, forwards to `api.anthropic.com`, and pipes SSE streaming through byte-for-byte (#51).
+- **Seamless Claude Code integration** — `nadirclaw claude onboard` / `shim` / `uninstall`. Onboarding detects models, maps them into tiers, persists `ANTHROPIC_BASE_URL` + `ANTHROPIC_MODEL` into `~/.claude/settings.json`, and installs a launchd / systemd auto-start unit (#51).
+- **Live model detection** — onboarding queries Anthropic's `/v1/models` using the stored token (Bearer for subscription tokens, `x-api-key` for API keys) instead of a hardcoded list; `--interactive` lets you pick a model per tier (#51).
+- **Pluggable complexity classifier** — `NADIRCLAW_COMPLEXITY_ANALYZER=binary` (default, ~10ms centroid) or `distilbert` (3-class fine-tuned DistilBERT predicting simple/mid/complex natively). The DistilBERT artifact downloads from the Hugging Face Hub on first use with a graceful fallback to binary (#51, #52).
+- **Pro upsell surfaces** — `nadirclaw savings` / `serve` / `report` and the README now surface Nadir Pro at high-intent moments with attribution-tagged URLs; new `demo/cost_vs_opus.py` zero-API-key demo (#53).
+- **Enriched `/v1/models`** — responses now include Anthropic-style `type` / `display_name` / `description` / `created_at` alongside the OpenAI-style fields.
+
+### Fixed
+- `ANTHROPIC_BASE_URL` is written as the bare host (Claude Code appends `/v1/messages` itself; a `/v1` suffix produced a broken `/v1/v1/messages` path) (#51).
+- Updated the stale Claude model fallback list from the 4.5/4.1 generation to the 4.6 family (#51).
+
 ## [0.15.0] - 2026-05-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ NadirClaw is the free, open-source core. If you are routing production traffic o
 |---|---|---|
 | **License** | MIT | Proprietary |
 | **Deploy** | Self-hosted, localhost | `api.getnadir.com` or self-host via Docker |
-| **Classifier** | Binary centroid, ~10ms | Trained classifier + 3-tier routing, higher accuracy |
+| **Classifier** | Binary centroid (~10ms) or opt-in 3-class DistilBERT | Trained classifier + 3-tier routing, higher accuracy |
 | **Storage** | Local JSONL + SQLite | Postgres (Supabase), multi-tenant |
 | **Dashboard** | Terminal + local web | Hosted web dashboard, per-team analytics |
 | **Cost tracking** | `nadirclaw savings` CLI | Live dashboard, monthly invoices, projected savings |
@@ -122,7 +122,8 @@ NadirClaw is the free, open-source core. If you are routing production traffic o
 - **Native Gemini support** — calls Gemini models directly via the Google GenAI SDK (not through LiteLLM)
 - **OAuth login** — use your subscription with `nadirclaw auth <provider> login` (OpenAI, Anthropic, Google), no API key needed
 - **Multi-provider** — supports Gemini, OpenAI, Anthropic, Ollama, and any LiteLLM-supported provider
-- **OpenAI-compatible API** — drop-in replacement for any tool that speaks the OpenAI chat completions API
+- **OpenAI-compatible API** — drop-in replacement for any tool that speaks the OpenAI chat completions API (`/v1/chat/completions`)
+- **Anthropic-compatible API** — `/v1/messages` endpoint so Anthropic-native clients like Claude Code route through NadirClaw; streaming piped through byte-for-byte
 - **Request reporting** — `nadirclaw report` with per-model and per-day cost breakdown (`--by-model --by-day`), anomaly flagging, filters, latency stats, tier breakdown, and token usage
 - **Log export** — `nadirclaw export --format csv|jsonl --since 7d` for offline analysis in spreadsheets or data tools
 - **Raw logging** — optional `--log-raw` flag to capture full request/response content for debugging and replay

--- a/nadirclaw/__init__.py
+++ b/nadirclaw/__init__.py
@@ -1,3 +1,3 @@
 """NadirClaw — Open-source LLM router."""
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"


### PR DESCRIPTION
## Summary

Cuts **v0.16.0**, bundling the Claude Code integration work merged since 0.15.0.

### Added
- Anthropic-compatible `/v1/messages` endpoint — Claude Code routes through NadirClaw (#51)
- Seamless Claude Code `onboard` / `shim` / `uninstall` (#51)
- Live Anthropic `/v1/models` detection + `--interactive` per-tier picker (#51)
- Pluggable complexity classifier: `binary` (default) or `distilbert` 3-class (#51, #52)
- Pro upsell surfaces in CLI + README + `demo/cost_vs_opus.py` (#53)
- Enriched `/v1/models` payload (Anthropic-style fields)

### Fixed
- `ANTHROPIC_BASE_URL` written as bare host (no `/v1` suffix)
- Stale 4.5/4.1 fallback model list → 4.6 family

## Changes in this PR
- `nadirclaw/__init__.py` — version bump `0.15.0` → `0.16.0`
- `CHANGELOG.md` — new `[0.16.0]` section
- `README.md` — Anthropic-compatible API in the feature list; OSS-vs-Pro table notes the opt-in DistilBERT classifier

## Release process
Once merged, publishing a GitHub Release tagged `v0.16.0` triggers `.github/workflows/publish.yml` → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)