### PR TITLE
feat(security): optional prompt guard + PII redactor (rebase of #31)

### DIFF
--- a/nadirclaw/pii_redactor.py
+++ b/nadirclaw/pii_redactor.py
@@ -1,0 +1,126 @@
+"""
+PII redaction for LLM output.
+
+Scans LLM responses for common PII patterns (email, phone, SSN, credit card)
+and redacts them before returning to the user.
+
+Configuration:
+  NADIRCLAW_PII_REDACTION: "none" (default) | "log_only" | "redact"
+
+Designed to run on non-streaming responses only. Streaming responses
+cannot be reliably redacted due to partial regex matches across chunks.
+"""
+
+import logging
+import os
+import re
+from typing import Tuple
+
+logger = logging.getLogger("nadirclaw.pii_redactor")
+
+_MODE = os.getenv("NADIRCLAW_PII_REDACTION", "none").lower()
+
+# ---------------------------------------------------------------------------
+# PII patterns
+# ---------------------------------------------------------------------------
+
+# Email addresses
+_EMAIL_RE = re.compile(
+    r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
+)
+
+# US phone numbers (various formats)
+_PHONE_RE = re.compile(
+    r"(?<!\d)"  # No digit before
+    r"(?:\+?1[-.\s]?)?"  # Optional country code
+    r"(?:\(?\d{3}\)?[-.\s]?)"  # Area code
+    r"\d{3}[-.\s]?\d{4}"  # Number
+    r"(?!\d)"  # No digit after
+)
+
+# US Social Security Numbers
+_SSN_RE = re.compile(
+    r"\b\d{3}-\d{2}-\d{4}\b"
+)
+
+# Credit card numbers (basic pattern, Luhn-validated)
+_CC_RE = re.compile(
+    r"\b(?:\d{4}[-\s]?){3}\d{4}\b"
+)
+
+
+def _luhn_check(number: str) -> bool:
+    """Validate a credit card number using the Luhn algorithm."""
+    digits = [int(d) for d in number if d.isdigit()]
+    if len(digits) < 13 or len(digits) > 19:
+        return False
+    checksum = 0
+    for i, digit in enumerate(reversed(digits)):
+        if i % 2 == 1:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        checksum += digit
+    return checksum % 10 == 0
+
+
+_PATTERNS = [
+    ("email", _EMAIL_RE, "[REDACTED_EMAIL]"),
+    ("phone", _PHONE_RE, "[REDACTED_PHONE]"),
+    ("ssn", _SSN_RE, "[REDACTED_SSN]"),
+    ("credit_card", _CC_RE, "[REDACTED_CC]"),
+]
+
+
+def scan_pii(text: str) -> list[dict]:
+    """Scan text for PII patterns. Returns list of detected PII with type and location."""
+    findings = []
+    for pii_type, pattern, _ in _PATTERNS:
+        for match in pattern.finditer(text):
+            # Extra Luhn validation for credit cards
+            if pii_type == "credit_card":
+                if not _luhn_check(match.group(0)):
+                    continue
+            findings.append({
+                "type": pii_type,
+                "start": match.start(),
+                "end": match.end(),
+            })
+    return findings
+
+
+def redact_pii(text: str) -> Tuple[str, bool]:
+    """Redact PII from text based on configured mode.
+
+    Returns:
+        Tuple of (possibly_redacted_text, pii_was_found).
+    """
+    if _MODE == "none":
+        return text, False
+
+    findings = scan_pii(text)
+    if not findings:
+        return text, False
+
+    # Log findings
+    types_found = set(f["type"] for f in findings)
+    logger.warning("PII detected in LLM output: types=%s count=%d", types_found, len(findings))
+
+    if _MODE == "log_only":
+        return text, True
+
+    # Mode is "redact" — replace all PII matches
+    result = text
+    # Process in reverse order to preserve character offsets
+    for pii_type, pattern, replacement in _PATTERNS:
+        if pii_type == "credit_card":
+            # Luhn-validated replacement
+            def _cc_replacer(match):
+                if _luhn_check(match.group(0)):
+                    return replacement
+                return match.group(0)
+            result = pattern.sub(_cc_replacer, result)
+        else:
+            result = pattern.sub(replacement, result)
+
+    return result, True

--- a/nadirclaw/pii_redactor.py
+++ b/nadirclaw/pii_redactor.py
@@ -12,13 +12,14 @@ cannot be reliably redacted due to partial regex matches across chunks.
 """
 
 import logging
-import os
 import re
 from typing import Tuple
 
+from nadirclaw.settings import settings
+
 logger = logging.getLogger("nadirclaw.pii_redactor")
 
-_MODE = os.getenv("NADIRCLAW_PII_REDACTION", "none").lower()
+# Mode is read lazily via `settings.PII_REDACTION_MODE` at call time.
 
 # ---------------------------------------------------------------------------
 # PII patterns
@@ -26,7 +27,7 @@ _MODE = os.getenv("NADIRCLAW_PII_REDACTION", "none").lower()
 
 # Email addresses
 _EMAIL_RE = re.compile(
-    r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
+    r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"
 )
 
 # US phone numbers (various formats)
@@ -89,13 +90,27 @@ def scan_pii(text: str) -> list[dict]:
     return findings
 
 
+def _cc_replacer_factory(replacement: str):
+    """Build a Luhn-validating re.sub replacer bound to a specific replacement string.
+
+    Using a factory (instead of a nested def inside the loop) avoids the
+    late-binding closure trap if `_PATTERNS` is ever reordered.
+    """
+    def _replace(match):
+        if _luhn_check(match.group(0)):
+            return replacement
+        return match.group(0)
+    return _replace
+
+
 def redact_pii(text: str) -> Tuple[str, bool]:
     """Redact PII from text based on configured mode.
 
     Returns:
         Tuple of (possibly_redacted_text, pii_was_found).
     """
-    if _MODE == "none":
+    mode = settings.PII_REDACTION_MODE
+    if mode == "none":
         return text, False
 
     findings = scan_pii(text)
@@ -106,20 +121,14 @@ def redact_pii(text: str) -> Tuple[str, bool]:
     types_found = set(f["type"] for f in findings)
     logger.warning("PII detected in LLM output: types=%s count=%d", types_found, len(findings))
 
-    if _MODE == "log_only":
+    if mode == "log_only":
         return text, True
 
-    # Mode is "redact" — replace all PII matches
+    # Mode is "redact" — replace all PII matches.
     result = text
-    # Process in reverse order to preserve character offsets
     for pii_type, pattern, replacement in _PATTERNS:
         if pii_type == "credit_card":
-            # Luhn-validated replacement
-            def _cc_replacer(match):
-                if _luhn_check(match.group(0)):
-                    return replacement
-                return match.group(0)
-            result = pattern.sub(_cc_replacer, result)
+            result = pattern.sub(_cc_replacer_factory(replacement), result)
         else:
             result = pattern.sub(replacement, result)
 

--- a/nadirclaw/prompt_guard.py
+++ b/nadirclaw/prompt_guard.py
@@ -1,0 +1,201 @@
+"""
+Prompt injection detection for NadirClaw.
+
+Heuristic-based (Tier 1) detection of adversarial prompt injection patterns.
+Designed to catch direct and indirect injection without flagging legitimate
+agentic workflows (tool definitions, structured system prompts, multi-turn
+conversations).
+
+Action modes (set via NADIRCLAW_PROMPT_GUARD env var):
+  - "log"   (default): Log detection, do not block
+  - "warn":  Log + add X-Prompt-Guard-Warning response header
+  - "block": Return 400 Bad Request on detection
+"""
+
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+logger = logging.getLogger("nadirclaw.prompt_guard")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_ACTION = os.getenv("NADIRCLAW_PROMPT_GUARD", "log").lower()
+if _ACTION not in ("log", "warn", "block"):
+    raise ValueError(
+        f"Invalid NADIRCLAW_PROMPT_GUARD={_ACTION!r}; expected log|warn|block"
+    )
+
+# ---------------------------------------------------------------------------
+# Detection patterns
+#
+# IMPORTANT: These patterns target adversarial override attempts specifically.
+# They must NOT match legitimate agentic patterns like:
+#   - Tool definitions with "instructions" fields
+#   - Multi-turn conversations with assistant/system roles
+#   - Structured delimiters used in prompt templates
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InjectionSignal:
+    """A detected injection signal with confidence and context."""
+    pattern_name: str
+    matched_text: str
+    confidence: float  # 0.0 to 1.0
+    message_index: int  # Which message in the array
+
+
+# Case-insensitive patterns that strongly indicate prompt injection
+# Each tuple: (pattern_name, compiled_regex, confidence)
+_INJECTION_PATTERNS: List[tuple] = [
+    # Direct instruction override
+    (
+        "instruction_override",
+        re.compile(
+            r"(?:ignore|disregard|forget|override|bypass)\s+"
+            r"(?:all\s+)?(?:previous|above|prior|earlier|your|the)\s+"
+            r"(?:instructions?|rules?|prompts?|guidelines?|constraints?|context)",
+            re.IGNORECASE,
+        ),
+        0.95,
+    ),
+    # Role reassignment
+    (
+        "role_reassignment",
+        re.compile(
+            r"(?:you\s+are\s+now|from\s+now\s+on\s+you\s+are|"
+            r"act\s+as\s+if\s+you\s+are|pretend\s+(?:to\s+be|you\s+are)|"
+            r"i\s+want\s+you\s+to\s+(?:act|behave|respond)\s+as)",
+            re.IGNORECASE,
+        ),
+        0.80,
+    ),
+    # System prompt extraction
+    (
+        "prompt_extraction",
+        re.compile(
+            r"(?:repeat|show|reveal|display|print|output|leak|give\s+me|tell\s+me)\s+"
+            r"(?:your|the|all|entire)?\s*"
+            r"(?:system\s+(?:prompt|message|instructions?)|"
+            r"initial\s+(?:prompt|instructions?)|"
+            r"(?:hidden|secret)\s+(?:prompt|instructions?|rules?))",
+            re.IGNORECASE,
+        ),
+        0.90,
+    ),
+    # Role confusion in user message (embedding JSON role objects)
+    (
+        "role_confusion_json",
+        re.compile(
+            r'\{\s*"role"\s*:\s*"(?:system|assistant)"\s*,\s*"content"\s*:',
+            re.IGNORECASE,
+        ),
+        0.70,
+    ),
+    # Delimiter injection (attempting to break out of sandboxed context)
+    (
+        "delimiter_injection",
+        re.compile(
+            r"(?:^|\n)\s*(?:<\|(?:im_start|im_end|system|endoftext)\|>|"
+            r"\[INST\]|\[/INST\]|<<SYS>>|<</SYS>>|"
+            r"### (?:System|Human|Assistant|Instruction):)",
+            re.IGNORECASE | re.MULTILINE,
+        ),
+        0.85,
+    ),
+    # Encoded payload detection (base64 blocks that look like instructions)
+    (
+        "encoded_payload",
+        re.compile(
+            r"(?:decode|eval|execute|run)\s+(?:this|the\s+following)?\s*"
+            r"(?:base64|b64|encoded|hex)\s*[:\-]?\s*[A-Za-z0-9+/=]{40,}",
+            re.IGNORECASE,
+        ),
+        0.75,
+    ),
+    # "DAN" / jailbreak patterns
+    (
+        "jailbreak_dan",
+        re.compile(
+            r"(?:DAN\s+mode|Developer\s+Mode|(?:Do\s+)?Anything\s+Now|"
+            r"STAN\s+mode|anti-?DAN|maximum\s+mode|god\s+mode)",
+            re.IGNORECASE,
+        ),
+        0.90,
+    ),
+]
+
+
+def scan_messages(
+    messages: list,
+    threshold: float = 0.70,
+) -> Optional[InjectionSignal]:
+    """
+    Scan a list of ChatMessage objects for prompt injection signals.
+
+    Only scans user-role messages (system and assistant messages are trusted
+    in the agentic context — they come from the operator or the model itself).
+
+    Returns the highest-confidence signal above threshold, or None.
+    """
+    best_signal: Optional[InjectionSignal] = None
+
+    for idx, msg in enumerate(messages):
+        # Only scan user and tool messages — system/assistant are trusted
+        if msg.role not in ("user", "tool"):
+            continue
+
+        text = msg.text_content() if hasattr(msg, "text_content") else str(getattr(msg, "content", ""))
+        if not text:
+            continue
+
+        for pattern_name, regex, confidence in _INJECTION_PATTERNS:
+            match = regex.search(text)
+            if match and confidence >= threshold:
+                signal = InjectionSignal(
+                    pattern_name=pattern_name,
+                    matched_text=match.group(0)[:100],
+                    confidence=confidence,
+                    message_index=idx,
+                )
+                if best_signal is None or signal.confidence > best_signal.confidence:
+                    best_signal = signal
+
+    return best_signal
+
+
+def check_and_act(messages: list) -> Optional[InjectionSignal]:
+    """
+    Run prompt injection scan and take configured action.
+
+    Returns the signal if detected (caller should add header in "warn" mode
+    or return 400 in "block" mode).
+    """
+    signal = scan_messages(messages)
+    if signal is None:
+        return None
+
+    logger.warning(
+        "Prompt injection detected: pattern=%s confidence=%.2f msg_idx=%d matched=%r",
+        signal.pattern_name,
+        signal.confidence,
+        signal.message_index,
+        signal.matched_text,
+    )
+
+    return signal
+
+
+def should_block() -> bool:
+    """Whether the configured action is 'block'."""
+    return _ACTION == "block"
+
+
+def should_warn() -> bool:
+    """Whether the configured action is 'warn' (add header)."""
+    return _ACTION == "warn"

--- a/nadirclaw/prompt_guard.py
+++ b/nadirclaw/prompt_guard.py
@@ -13,22 +13,17 @@ Action modes (set via NADIRCLAW_PROMPT_GUARD env var):
 """
 
 import logging
-import os
 import re
 from dataclasses import dataclass
 from typing import List, Optional
 
+from nadirclaw.settings import settings
+
 logger = logging.getLogger("nadirclaw.prompt_guard")
 
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
-
-_ACTION = os.getenv("NADIRCLAW_PROMPT_GUARD", "log").lower()
-if _ACTION not in ("log", "warn", "block"):
-    raise ValueError(
-        f"Invalid NADIRCLAW_PROMPT_GUARD={_ACTION!r}; expected log|warn|block"
-    )
+# Configuration is read lazily via `settings.PROMPT_GUARD_ACTION` at call
+# time — bad env values log a warning and fall back to "log" rather than
+# crashing the entire package at import.
 
 # ---------------------------------------------------------------------------
 # Detection patterns
@@ -138,8 +133,11 @@ def scan_messages(
     """
     Scan a list of ChatMessage objects for prompt injection signals.
 
-    Only scans user-role messages (system and assistant messages are trusted
-    in the agentic context — they come from the operator or the model itself).
+    Scope: only user- and tool-role messages are scanned. System and
+    assistant messages are intentionally trusted in the agentic context —
+    they come from the operator or the model itself. This means indirect
+    injection via crafted assistant replay messages is *not* detected here;
+    that surface needs an upstream defense.
 
     Returns the highest-confidence signal above threshold, or None.
     """
@@ -193,9 +191,9 @@ def check_and_act(messages: list) -> Optional[InjectionSignal]:
 
 def should_block() -> bool:
     """Whether the configured action is 'block'."""
-    return _ACTION == "block"
+    return settings.PROMPT_GUARD_ACTION == "block"
 
 
 def should_warn() -> bool:
     """Whether the configured action is 'warn' (add header)."""
-    return _ACTION == "warn"
+    return settings.PROMPT_GUARD_ACTION == "warn"

--- a/nadirclaw/server.py
+++ b/nadirclaw/server.py
@@ -1260,6 +1260,15 @@ async def chat_completions(
                    f"Maximum is {_MAX_CONTENT_LENGTH:,} chars.",
         )
 
+    # --- Prompt injection detection ---
+    from nadirclaw.prompt_guard import check_and_act, should_block, should_warn
+    _injection_signal = check_and_act(request.messages)
+    if _injection_signal and should_block():
+        raise HTTPException(
+            status_code=400,
+            detail="Request blocked: potential prompt injection detected",
+        )
+
     start_time = time.time()
     request_id = str(uuid.uuid4())
 
@@ -1635,6 +1644,13 @@ async def chat_completions(
                 "reasoning_tokens": response_data["reasoning_tokens"],
             }
 
+        # --- PII redaction on LLM output (non-streaming only) ---
+        from nadirclaw.pii_redactor import redact_pii
+        if message.get("content"):
+            message["content"], pii_found = redact_pii(message["content"])
+            if pii_found:
+                logger.info("PII redacted from response for request %s", request_id)
+
         response_body = {
             "id": request_id,
             "object": "chat.completion",
@@ -1656,7 +1672,10 @@ async def chat_completions(
             },
         }
 
-        return JSONResponse(content=response_body)
+        resp = JSONResponse(content=response_body)
+        if _injection_signal and should_warn():
+            resp.headers["X-Prompt-Guard-Warning"] = _injection_signal.pattern_name
+        return resp
 
     except HTTPException:
         raise  # Re-raise FastAPI HTTP exceptions as-is

--- a/nadirclaw/settings.py
+++ b/nadirclaw/settings.py
@@ -292,6 +292,32 @@ class Settings:
             return 500
 
     @property
+    def PROMPT_GUARD_ACTION(self) -> str:
+        """Prompt injection guard action: log, warn, block. Default: log."""
+        val = os.getenv("NADIRCLAW_PROMPT_GUARD", "log").lower()
+        if val not in ("log", "warn", "block"):
+            _settings_logger.warning(
+                "Invalid NADIRCLAW_PROMPT_GUARD=%r — expected log|warn|block. "
+                "Falling back to 'log'.",
+                val,
+            )
+            return "log"
+        return val
+
+    @property
+    def PII_REDACTION_MODE(self) -> str:
+        """PII redaction mode: none, log_only, redact. Default: none."""
+        val = os.getenv("NADIRCLAW_PII_REDACTION", "none").lower()
+        if val not in ("none", "log_only", "redact"):
+            _settings_logger.warning(
+                "Invalid NADIRCLAW_PII_REDACTION=%r — expected none|log_only|redact. "
+                "Falling back to 'none'.",
+                val,
+            )
+            return "none"
+        return val
+
+    @property
     def has_explicit_tiers(self) -> bool:
         """True if SIMPLE_MODEL and COMPLEX_MODEL are explicitly set via env."""
         return bool(


### PR DESCRIPTION
Rebase of #31 onto current `main` after #30 merged. Carries the two original author commits (`e80e4ad` + `24b9fff`) — the conflict was a pure additive collision in `settings.py` (#30 added CORS/HSTS/log properties; #31 added prompt-guard/PII properties at the same insertion point).

## What this adds

Two opt-in security modules — both **disabled by default**, so zero behavior change unless explicitly configured.

**`prompt_guard.py` — heuristic prompt-injection detection**
- 7 patterns: instruction override, role reassignment, prompt extraction, JSON role confusion, delimiter injection, encoded payloads, DAN/jailbreak
- `NADIRCLAW_PROMPT_GUARD`: `log` (default) / `warn` / `block`
- Only scans user/tool messages (system/assistant trusted)

**`pii_redactor.py` — PII detection + redaction**
- Detects email, US phone, SSN, credit card (Luhn-validated)
- `NADIRCLAW_PII_REDACTION`: `none` (default) / `log_only` / `redact`
- Non-streaming responses only (documented limitation)

## Why merge this rebase instead of #31

#31 was branched off #30, so after #30 squash-merged, #31's diff against `main` showed every commit in main since the branch point. Cherry-picking the two PR-31-specific commits onto fresh `main` produces a clean 4-file diff. Original commits preserved by author.

## Verification

- 642 tests pass (`pytest tests/ -x --ignore=tests/test_server.py`)
- Import-time safety: `NADIRCLAW_PROMPT_GUARD=garbage python -c 'import nadirclaw'` succeeds, falls back to `log` with a warning (no `ValueError`)
- Settings pattern: env vars set after import flow through `settings.PROMPT_GUARD_ACTION` / `settings.PII_REDACTION_MODE`
- Email regex fix: `foo@bar.A|B` no longer matches; legitimate emails do
- PII roundtrip: `Contact: foo@bar.com or 555-123-4567` → `Contact: [REDACTED_EMAIL] or [REDACTED_PHONE]`
- Luhn-valid CC redacted; random 16-digit non-Luhn order ID is not

Closes #31.

Co-Authored-By: pradumna-gautam <pgautam8601@gmail.com>