### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to NadirClaw will be documented in this file.
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-05-15
+
+### Added
+- **Configurable embedding backends for the centroid classifier** — `NADIRCLAW_EMBEDDING_BACKEND` (default `sentence-transformers`; also `ollama` via `/api/embed`), `NADIRCLAW_EMBEDDING_MODEL`, `NADIRCLAW_EMBEDDING_API_BASE`, and `NADIRCLAW_CENTROID_DIR`. Custom centroid directories require a `centroid_metadata.json` (schema-versioned, with `prototypes_hash` for traceability) so users never silently mismatch a self-built centroid against a different encoder. `nadirclaw build-centroids` gains `--backend`, `--model`, `--api-base`, `--output-dir` flags. Original work by @clawSean (#50).
+- **Optional prompt-injection guard** — `nadirclaw/prompt_guard.py`. Heuristic detection of 7 patterns (instruction override, role reassignment, prompt extraction, JSON role confusion, delimiter injection, encoded payloads, DAN/jailbreak). `NADIRCLAW_PROMPT_GUARD`: `log` (default) / `warn` / `block`. Scans only user/tool messages — system/assistant treated as trusted. Original work by @pradumna-gautam (#55, supersedes #31).
+- **Optional PII redactor** — `nadirclaw/pii_redactor.py`. Detects email, US phone, SSN, and Luhn-validated credit-card numbers. `NADIRCLAW_PII_REDACTION`: `none` (default) / `log_only` / `redact`. Non-streaming responses only. Original work by @pradumna-gautam (#55).
+
+### Security
+- **Production hardening baseline** — recommended for anyone exposing `nadirclaw serve` beyond localhost. Original work by @pradumna-gautam (#30).
+  - **CORS**: explicit allowlist via `NADIRCLAW_CORS_ORIGINS`; localhost regex default; never wildcard + credentials.
+  - **Auth**: constant-time token comparison via `hmac.compare_digest` to defeat timing-side-channel guessing.
+  - **Security headers** on every response: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, `Cache-Control: no-store` on `/v1/*`, opt-in HSTS via `NADIRCLAW_HSTS=true`.
+  - **Bounds validation** on `ChatCompletionRequest`: caps on messages (500), `max_tokens` (100K), `temperature` (0–2), `top_p` (0–1), `n` (1–8) — closes a cost-amplification surface.
+  - **Sanitized validation errors** — Pydantic internals no longer leak to clients; full details still server-side logged.
+  - **Async logging** — SQLite writes moved off the event loop into a `ThreadPoolExecutor`, with `done_callback` exception logging and `shutdown(wait=True)` on SIGTERM so queued entries drain instead of dropping.
+  - **Prompt truncation** — 500-char default in SQLite request logs (configurable via `NADIRCLAW_LOG_PROMPT_TRUNCATE`); API-key shaped tokens (`sk-…`, `AIza…`, `ghp_…`, `gho_…`, `xox[bpars]-…`) redacted from logged system prompts.
+
 ## [0.16.0] - 2026-05-14
 
 ### Added

--- a/nadirclaw/__init__.py
+++ b/nadirclaw/__init__.py
@@ -1,3 +1,3 @@
 """NadirClaw — Open-source LLM router."""
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"


### PR DESCRIPTION
Bundles the security + classifier-extensibility work landed since 0.16.0 (yesterday):

- **Configurable embedding backends** for the centroid classifier (#50, @clawSean)
- **Production security hardening** — CORS, auth, headers, bounds, async logging (#30, @pradumna-gautam)
- **Optional prompt-injection guard + PII redactor** modules (#55, @pradumna-gautam, supersedes #31)

### Why a release one day after 0.16.0

These three PRs all add user-visible knobs (`NADIRCLAW_EMBEDDING_BACKEND`, `NADIRCLAW_CORS_ORIGINS`, `NADIRCLAW_PROMPT_GUARD`, `NADIRCLAW_PII_REDACTION`, etc.) that anyone running `nadirclaw serve` exposed beyond localhost will want to pin to a versioned release. The security baseline in particular is recommended for anyone past pure-local use — better to give that a version number than leave it at `HEAD`.

### Diff

- `nadirclaw/__init__.py` — `__version__ = "0.17.0"`
- `CHANGELOG.md` — new `[0.17.0]` block under `### Added` and `### Security`

### Verification

- 642 tests passing on the rebased branch (pre-merge of #55), 612 on the post-#30 main.
- CI green on 3.10/3.11/3.12 for #30, #50, and #55 individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)