### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to NadirClaw will be documented in this file.
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-05-25
+
+### Added
+- **Application Default Credentials (ADC) for Gemini** — when no `GOOGLE_API_KEY` is set, the Gemini path now falls back to `google.auth.default()` so users can authenticate via `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` (Vertex AI / gcloud-managed creds) instead of pasting a key. Original work by @froody (#57).
+- **`nadirclaw status` displays the mid-tier model** when one is configured, alongside simple/complex (#57).
+
+### Fixed
+- **Gemini streaming was broken** — `_dispatch_model_stream` consumed `_stream_gemini` (an async generator) with a plain `for` loop, which would raise `TypeError: 'async_generator' object is not iterable` on any actual streaming Gemini call. Now uses `async for`, and chunk / `finish_reason` parsing is robust to the google-genai SDK returning enum-like objects (#57).
+- **`savings` no longer crashes on `None` values** in the request log for `selected_model` and `tier` — these show up for failed / aborted requests and previously broke the report (#57).
+
 ## [0.17.0] - 2026-05-15
 
 ### Added

--- a/nadirclaw/__init__.py
+++ b/nadirclaw/__init__.py
@@ -1,3 +1,3 @@
 """NadirClaw — Open-source LLM router."""
 
-__version__ = "0.17.0"
+__version__ = "0.18.0"


### PR DESCRIPTION
Bundles the ADC support + Gemini streaming fix landed since 0.17.0:

- **Application Default Credentials for Gemini** (#57, @froody) — falls back to `google.auth.default()` when no `GOOGLE_API_KEY` is set, so users can auth via `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` (Vertex AI / gcloud creds).
- **Fix Gemini streaming** (#57, @froody) — `_dispatch_model_stream` was consuming `_stream_gemini` (an async generator) with a plain `for` loop and would have raised `TypeError` on any real streaming Gemini call. Now uses `async for`. Robust to google-genai SDK returning enum-like chunks / `finish_reason`.
- **`savings` tolerates None values** (#57, @froody) — `selected_model: None` / `tier: None` in real logs (failed/aborted requests) no longer crash the report.
- **`nadirclaw status` displays the mid model** (#57, @froody) when one is configured.

### Why a release

The Gemini streaming bug was latent — anyone who actually hit `stream=true` on a Gemini-routed request would have gotten `TypeError: 'async_generator' object is not iterable`. Worth pinning a version. ADC is also a meaningful UX win for Vertex AI users who can't easily mint an API key.

### Diff

- `nadirclaw/__init__.py` — `__version__ = "0.18.0"`
- `CHANGELOG.md` — new `[0.18.0]` block under `### Added` and `### Fixed`

### Verification

- CI green on #57 across Python 3.10 / 3.11 / 3.12 ([run 26362224241](https://github.com/NadirRouter/NadirClaw/actions/runs/26362224241)).
- 663 tests passing on main at the merge of #57.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)