### PR TITLE
v0.19.1: Fix HuggingFace path to nadirclaw/cascade-verifier-v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ N-tier dispatch with the bundled 3-tier profile, or write your own.
 Schema reference: `nadirclaw/tier_config/schema.py`. Sample profiles:
 `nadirclaw/tier_config/profiles/`.
 
-### Trained verifier (NadirRouter/cascade-verifier-v1)
+### Trained verifier (nadirclaw/cascade-verifier-v1)
 
 The default `n2_default` profile escalates via the rule-based
 `HeuristicVerifier` shipped in this repo — no extra dependencies, runs
@@ -458,7 +458,7 @@ cross-encoder verifier.
 This is the frozen DeBERTa-v3-small snapshot used in the
 [RouterArena PR #112](https://github.com/RouteWorks/RouterArena/pull/112)
 submission (arena_F 0.7358). It is released under MIT as
-[`NadirRouter/cascade-verifier-v1`](https://huggingface.co/NadirRouter/cascade-verifier-v1)
+[`nadirclaw/cascade-verifier-v1`](https://huggingface.co/nadirclaw/cascade-verifier-v1)
 on HuggingFace so the RouterArena number is reproducible end-to-end
 with the open-source router.
 

--- a/nadirclaw/__init__.py
+++ b/nadirclaw/__init__.py
@@ -1,3 +1,3 @@
 """NadirClaw — Open-source LLM router."""
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"

--- a/nadirclaw/cascade.py
+++ b/nadirclaw/cascade.py
@@ -473,7 +473,7 @@ class NTierCascade:
         # `cascade.verifier` from the profile. "heuristic" (default)
         # keeps the zero-dependency rule-based verifier. "trained"
         # lazily loads the DeBERTa-v3-small cross-encoder from
-        # NadirRouter/cascade-verifier-v1 (requires the optional
+        # nadirclaw/cascade-verifier-v1 (requires the optional
         # `nadirclaw[trained]` extras).
         if verifier is not None:
             self.verifier = verifier

--- a/nadirclaw/tier_config/profiles/n2_trained.yaml
+++ b/nadirclaw/tier_config/profiles/n2_trained.yaml
@@ -2,7 +2,7 @@
 #
 # Same N=2 tier layout as n2_default, but routes verifier decisions
 # through the trained DeBERTa-v3-small cross-encoder released as
-# NadirRouter/cascade-verifier-v1 on HuggingFace, instead of the
+# nadirclaw/cascade-verifier-v1 on HuggingFace, instead of the
 # rule-based HeuristicVerifier.
 #
 # Use this profile to reproduce the RouterArena PR #112 result
@@ -33,7 +33,7 @@ cascade:
   # Use the trained DeBERTa-v3-small cross-encoder instead of the
   # rule-based heuristic. Loaded lazily on first cascade call.
   verifier: trained
-  verifier_model: NadirRouter/cascade-verifier-v1
+  verifier_model: nadirclaw/cascade-verifier-v1
 
 tiers:
   # ----- Cheap tier: workhorses for simple/mid prompts. -----

--- a/nadirclaw/tier_config/schema.py
+++ b/nadirclaw/tier_config/schema.py
@@ -66,13 +66,13 @@ class CascadeConfig(BaseModel):
     max_escalations: Optional[int] = Field(default=None, ge=0)
     # Which verifier the cascade should use. `heuristic` (default) uses
     # the rule-based HeuristicVerifier shipped in this repo. `trained`
-    # loads NadirRouter/cascade-verifier-v1 from HuggingFace and
+    # loads nadirclaw/cascade-verifier-v1 from HuggingFace and
     # requires the `trained` extras (pip install nadirclaw[trained]).
     verifier: str = "heuristic"
     # HuggingFace model id or local path for the trained verifier.
     # Only consulted when verifier == "trained". Defaults to the
     # released v1 snapshot.
-    verifier_model: str = "NadirRouter/cascade-verifier-v1"
+    verifier_model: str = "nadirclaw/cascade-verifier-v1"
 
     @model_validator(mode="after")
     def _check_mode(self) -> "CascadeConfig":

--- a/nadirclaw/trained_verifier.py
+++ b/nadirclaw/trained_verifier.py
@@ -9,7 +9,7 @@ open-source NadirClaw router.
 What's released
 ---------------
 * Frozen INT8 / FP32 weights at the HuggingFace model id
-  ``NadirRouter/cascade-verifier-v1``.
+  ``nadirclaw/cascade-verifier-v1``.
 * Tokenizer + config to load via the standard
   ``transformers.AutoModelForSequenceClassification`` pipeline.
 
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 # Default HuggingFace model id for the released snapshot. Override with
 # the ``NADIRCLAW_TRAINED_VERIFIER_MODEL`` env var or the ``model_id``
 # constructor argument if you mirror the weights elsewhere.
-DEFAULT_MODEL_ID = "NadirRouter/cascade-verifier-v1"
+DEFAULT_MODEL_ID = "nadirclaw/cascade-verifier-v1"
 
 # Default acceptance threshold. Calibrated against the same held-out
 # RouterBench test split as the HeuristicVerifier default. The trained
@@ -103,7 +103,7 @@ class TrainedVerifier:
     ----------
     model_id:
         HuggingFace model id or local path. Defaults to
-        ``NadirRouter/cascade-verifier-v1``.
+        ``nadirclaw/cascade-verifier-v1``.
     threshold:
         Score cutoff for acceptance. Defaults to 0.80 (same as the
         heuristic, so cascade behaviour is consistent when you swap).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ telemetry = [
 ]
 trained = [
     # Optional dependency for the TrainedVerifier (DeBERTa-v3-small
-    # cross-encoder loaded from NadirRouter/cascade-verifier-v1).
+    # cross-encoder loaded from nadirclaw/cascade-verifier-v1).
     # The heuristic verifier remains the default for the cascade,
     # so users who do not want the transformer stack pay nothing.
     "transformers>=4.40",

--- a/tests/test_trained_verifier.py
+++ b/tests/test_trained_verifier.py
@@ -170,7 +170,7 @@ def test_trained_verifier_default_model_id():
     """The released v1 snapshot id should be the constructor default."""
     from nadirclaw.trained_verifier import DEFAULT_MODEL_ID, TrainedVerifier
 
-    assert DEFAULT_MODEL_ID == "NadirRouter/cascade-verifier-v1"
+    assert DEFAULT_MODEL_ID == "nadirclaw/cascade-verifier-v1"
     v = TrainedVerifier(threshold=0.8, device="cpu")
     assert v.model_id == DEFAULT_MODEL_ID
 
@@ -198,7 +198,7 @@ def test_n2_trained_profile_loads():
     assert profile.profile_name == "n2_trained"
     assert profile.num_tiers == 2
     assert profile.cascade.verifier == "trained"
-    assert profile.cascade.verifier_model == "NadirRouter/cascade-verifier-v1"
+    assert profile.cascade.verifier_model == "nadirclaw/cascade-verifier-v1"
     assert profile.cascade.acceptance_threshold == 0.80
 
 


### PR DESCRIPTION
## Summary

v0.19.0 shipped with the `TrainedVerifier` hardcoded to load weights from `NadirRouter/cascade-verifier-v1`, but the weights are actually published at [`nadirclaw/cascade-verifier-v1`](https://huggingface.co/nadirclaw/cascade-verifier-v1) under the existing `nadirclaw` HuggingFace org. As shipped, `pip install nadirclaw[trained]` + `n2_trained` profile would 404 on first call.

This patch updates every reference (default constant, schema default, n2_trained YAML, README, tests) to the actual published location. No API change. `pip install nadirclaw[trained]` now works end-to-end.

## Files touched

- `pyproject.toml` (comment) + version bump in `nadirclaw/__init__.py` (0.19.0 → 0.19.1)
- `README.md` (heading + HF link)
- `nadirclaw/trained_verifier.py` (`DEFAULT_MODEL_ID` + docstrings)
- `nadirclaw/cascade.py` (comment)
- `nadirclaw/tier_config/schema.py` (default value + comment)
- `nadirclaw/tier_config/profiles/n2_trained.yaml` (default + comment)
- `tests/test_trained_verifier.py` (assertions)

## Test plan

- [x] `pytest tests/test_trained_verifier.py -v` — 8 passed, 1 skipped (heavy-weight gated test)
- [x] `grep -rn "NadirRouter/cascade-verifier"` — zero matches
- [ ] CI green on this PR

## Why this matters

This closes the reproducibility commitment in the [RouterArena PR #112 submission](https://github.com/RouteWorks/RouterArena/pull/112) (arena_F 0.7358). With the corrected path, anyone can reproduce the score end-to-end with the open-source router.