### PR TITLE
Fix OpenAI OAuth redirect_uri to use localhost (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to NadirClaw will be documented in this file.
 
 ## [Unreleased]
 
+## [0.19.3] - 2026-06-12
+
+### Fixed
+- **OpenAI OAuth login failed with `authorize_hydra_invalid_request`** — `nadirclaw auth openai login` sent `redirect_uri=http://127.0.0.1:1455/auth/callback` in the authorize request while the callback server bound and printed `localhost`. OpenAI's Hydra authorization server exact-matches `redirect_uri` against the client allow-list and rejected the `127.0.0.1` variant before the login screen. Now uses `localhost` consistently, matching the callback server and the Antigravity/Gemini flows (#67, #69).
+
 ## [0.18.0] - 2026-05-25
 
 ### Added

--- a/nadirclaw/__init__.py
+++ b/nadirclaw/__init__.py
@@ -1,3 +1,3 @@
 """NadirClaw — Open-source LLM router."""
 
-__version__ = "0.19.2"
+__version__ = "0.19.3"

--- a/nadirclaw/oauth.py
+++ b/nadirclaw/oauth.py
@@ -234,7 +234,12 @@ def login_openai(timeout: int = 300) -> Optional[dict]:
     code_challenge = _generate_code_challenge(code_verifier)
     state = secrets.token_urlsafe(32)
 
-    redirect_uri = f"http://127.0.0.1:{_CALLBACK_PORT}{_CALLBACK_PATH}"
+    # Must exactly match the redirect_uri registered for the OpenAI OAuth client
+    # AND the callback server below (which binds/prints localhost). Hydra exact-
+    # matches this value against the client allow-list and rejects the authorize
+    # request with `authorize_hydra_invalid_request` on any mismatch — using
+    # 127.0.0.1 here instead of localhost triggers exactly that error (issue #67).
+    redirect_uri = f"http://localhost:{_CALLBACK_PORT}{_CALLBACK_PATH}"
 
     # Build authorization URL
     auth_params = {


### PR DESCRIPTION
## Summary

Fixes #67 — `nadirclaw auth openai login` fails with `error_code: authorize_hydra_invalid_request` before the OpenAI login screen ever appears.

## Root cause

`login_openai()` had an internal inconsistency in the redirect URI:

- The callback server **binds to and prints** `http://localhost:1455/auth/callback` (`_start_callback_server`).
- But the authorize request **sent** `redirect_uri=http://127.0.0.1:1455/auth/callback`.

OpenAI's Hydra authorization server exact-matches `redirect_uri` against the OAuth client's allow-list. The reused Codex CLI client (`app_EMoamEEZ73f0CkXaXp7hrann`) registers the `localhost` form, so the `127.0.0.1` variant is rejected up front with `authorize_hydra_invalid_request` — exactly the reported symptom (reproduced identically via pipx and source, confirming it is not an install issue).

Every other flow in `oauth.py` (Antigravity, Gemini) already uses `localhost` consistently; OpenAI was the outlier.

## Fix

Use `localhost` for the authorize `redirect_uri`, matching the callback server and the other flows. The token exchange reuses the same `redirect_uri` variable, so it stays consistent through the whole flow.

## Note for the reporter

This corrects a definite internal inconsistency. If the error persists after this change, please share the redacted authorize URL — there is a small chance OpenAI also tightened the `client_id`/`audience` allow-list, which would need a separate follow-up.