### PR TITLE
fix(server): reconcile request params the routed model rejects (#83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to NadirClaw will be documented in this file.
 ### Changed
 - **License changed from MIT to the PolyForm Noncommercial License 1.0.0.** NadirClaw is now free for any noncommercial use (personal, research, education, evaluation, and noncommercial organizations). Commercial use requires a separate commercial license, available via [getnadir.com](https://getnadir.com). This applies to new versions; releases previously published under MIT remain available under MIT. The bundled `wide_deep_asym_v3` classifier weights and the `cascade-verifier-v1` snapshot are now released under the same noncommercial terms.
 
+### Fixed
+- **`/v1/messages` forwarded parameters the routed model cannot accept, so cheap tiers 400 on every request** — clients pick request parameters from the model id they can see, which behind the router is an alias (`nadir-auto`), so they assume the newest capabilities. When routing then selected an older, cheaper model, the request carried parameters that model rejects and every request failed (#83). The passthrough now reconciles the request against the 400 it gets back and retries within the same request, bounded to 4 attempts: `thinking: {"type":"adaptive"}` is rewritten to `{"type":"enabled","budget_tokens":N}`, an unsupported `effort` hint is dropped, and `system`/`developer` turns are folded into the top-level `system` field (the same fix already applied to the OAuth completion path in 0.21.1). Each fix is remembered per model, so the discovery costs one round trip per model per process instead of one per request. Applied fixes are recorded in `requests.jsonl` as `modifiers_applied` entries and signalled by an `X-NadirClaw-Params-Reconciled` response header. Verified against a live Anthropic subscription: `claude-haiku-4-5` went from 3 failed upstream calls per Claude Code request to a single successful one.
+
 ## [0.21.1] - 2026-06-25
 
 ### Added

--- a/nadirclaw/server.py
+++ b/nadirclaw/server.py
@@ -2484,6 +2484,21 @@ _ANTHROPIC_COUNT_TOKENS_UPSTREAM = "https://api.anthropic.com/v1/messages/count_
 # Anthropic 400 when the requested max_tokens exceeds the routed model's ceiling:
 #   "max_tokens: 100000 > 64000, which is the maximum allowed ..."
 _MAX_TOKENS_400_RE = re.compile(r"max_tokens:\s*(\d+)\s*>\s*(\d+)")
+# Anthropic 400s raised when a client sends a parameter the routed model does not
+# support. Clients pick these parameters from the model id they can see, which
+# behind this proxy is a router alias, so they assume the newest capabilities (#83).
+_ADAPTIVE_THINKING_400_RE = re.compile(r"adaptive thinking is not supported", re.I)
+_EFFORT_400_RE = re.compile(r"does not support the effort parameter", re.I)
+_SYSTEM_ROLE_400_RE = re.compile(r"role '?system'? is not supported", re.I)
+# Anthropic requires 1024 <= budget_tokens < max_tokens for `thinking.type=enabled`.
+_MIN_THINKING_BUDGET = 1024
+_MAX_THINKING_BUDGET = 32000
+# Upper bound on reconcile round trips for one request, so a misbehaving upstream
+# can never loop. Four covers the known fixes plus the max_tokens clamp (#73).
+_MAX_RECONCILE_ATTEMPTS = 4
+# model -> names of reconcilers it has needed, learned from upstream 400s. Cached
+# per process so the fixes cost one round trip per model, not one per request.
+_MODEL_PARAM_FIXES: Dict[str, set] = {}
 
 
 def _anthropic_auth_headers(raw: Request, body: Dict[str, Any]) -> Dict[str, str]:
@@ -2524,6 +2539,128 @@ def _parse_max_tokens_ceiling(error_text: str) -> Optional[int]:
         return int(m.group(2))
     except (ValueError, IndexError):
         return None
+
+
+def _downgrade_adaptive_thinking(body: Dict[str, Any]) -> Optional[str]:
+    """Rewrite ``thinking: {"type": "adaptive"}`` into a shape older models accept.
+
+    Models that predate adaptive thinking accept
+    ``{"type": "enabled", "budget_tokens": N}``, so rewrite to that and keep the
+    caller's intent (let the model think) instead of failing the request.
+    """
+    thinking = body.get("thinking")
+    if not isinstance(thinking, dict) or thinking.get("type") != "adaptive":
+        return None
+    max_tokens = body.get("max_tokens")
+    if not isinstance(max_tokens, int) or max_tokens <= _MIN_THINKING_BUDGET:
+        # No room for a valid budget below max_tokens, so thinking cannot be
+        # honoured at all. Drop it rather than forward a mode that must 400.
+        body.pop("thinking", None)
+        return "thinking_downgrade(adaptive\u2192off)"
+    budget = max(_MIN_THINKING_BUDGET, min(_MAX_THINKING_BUDGET, max_tokens - 1))
+    downgraded: Dict[str, Any] = {"type": "enabled", "budget_tokens": budget}
+    if thinking.get("display") is not None:
+        downgraded["display"] = thinking["display"]
+    body["thinking"] = downgraded
+    return f"thinking_downgrade(adaptive\u2192enabled, budget={budget})"
+
+
+def _drop_effort(body: Dict[str, Any]) -> Optional[str]:
+    """Remove the ``effort`` hint that older models reject.
+
+    ``effort`` only shapes how hard a model tries, so dropping it changes cost and
+    latency but never correctness — unlike failing the request outright.
+    """
+    output_config = body.get("output_config")
+    if isinstance(output_config, dict) and "effort" in output_config:
+        effort = output_config.pop("effort")
+        if not output_config:
+            body.pop("output_config", None)
+        return f"effort_drop({effort})"
+    if "effort" in body:
+        return f"effort_drop({body.pop('effort')})"
+    return None
+
+
+def _fold_system_messages(body: Dict[str, Any]) -> Optional[str]:
+    """Move ``system``/``developer`` turns out of ``messages`` into ``system``.
+
+    Newer models accept a system turn inside the messages array; older ones only
+    accept the top-level ``system`` field. Folding preserves the instructions
+    instead of dropping them.
+    """
+    messages = body.get("messages")
+    if not isinstance(messages, list):
+        return None
+    moved: list[Any] = []
+    kept: list[Any] = []
+    for message in messages:
+        if isinstance(message, dict) and message.get("role") in ("system", "developer"):
+            moved.append(message.get("content"))
+        else:
+            kept.append(message)
+    # Anthropic requires at least one message, so a body of nothing but system
+    # turns cannot be folded — leave it untouched and let the error surface.
+    if not moved or not kept:
+        return None
+    blocks: list[Any] = []
+    existing = body.get("system")
+    if isinstance(existing, str):
+        blocks.append({"type": "text", "text": existing})
+    elif isinstance(existing, list):
+        blocks.extend(existing)
+    for content in moved:
+        if isinstance(content, str):
+            blocks.append({"type": "text", "text": content})
+        elif isinstance(content, list):
+            blocks.extend(block for block in content if isinstance(block, dict))
+    body["system"] = blocks
+    body["messages"] = kept
+    return f"system_role_fold({len(moved)})"
+
+
+# (name, matching 400, fixer). Order is the order fixes are applied.
+_PARAM_RECONCILERS: Tuple[Tuple[str, Any, Any], ...] = (
+    ("thinking", _ADAPTIVE_THINKING_400_RE, _downgrade_adaptive_thinking),
+    ("effort", _EFFORT_400_RE, _drop_effort),
+    ("system_role", _SYSTEM_ROLE_400_RE, _fold_system_messages),
+)
+
+
+def _reconcile_from_error(body: Dict[str, Any], model: str, error_text: str) -> list[str]:
+    """Fix the parameter an Anthropic 400 rejected and remember it for this model.
+
+    Returns the modifier strings applied. An empty list means nothing matched, so
+    the caller must surface the error rather than retry.
+    """
+    if not error_text:
+        return []
+    modifiers = []
+    for name, pattern, fixer in _PARAM_RECONCILERS:
+        if not pattern.search(error_text):
+            continue
+        _MODEL_PARAM_FIXES.setdefault(model, set()).add(name)
+        modifier = fixer(body)
+        if modifier:
+            modifiers.append(modifier)
+            logger.warning("%s rejected a parameter \u2192 %s", model, modifier)
+    return modifiers
+
+
+def _preapply_known_fixes(body: Dict[str, Any], model: str) -> list[str]:
+    """Apply the fixes this model has already demanded, before the first call."""
+    needed = _MODEL_PARAM_FIXES.get(model)
+    if not needed:
+        return []
+    modifiers = []
+    for name, _pattern, fixer in _PARAM_RECONCILERS:
+        if name in needed:
+            modifier = fixer(body)
+            if modifier:
+                modifiers.append(modifier)
+    return modifiers
+
+
 
 
 def _parse_anthropic_sse_usage(text: str) -> Tuple[Optional[int], Optional[int]]:
@@ -2568,6 +2705,7 @@ def _record_messages_usage(
     status: str = "ok",
     latency_ms: Optional[int] = None,
     clamped: bool = False,
+    extra_modifiers: Optional[list[str]] = None,
     response_preview: str = "",
     error: Optional[str] = None,
 ) -> None:
@@ -2594,6 +2732,10 @@ def _record_messages_usage(
         entry["total_latency_ms"] = latency_ms
     if clamped:
         entry["max_tokens_clamped"] = True
+    if extra_modifiers:
+        entry["modifiers_applied"] = list(entry.get("modifiers_applied") or []) + list(
+            extra_modifiers
+        )
     if response_preview:
         entry["response_preview"] = response_preview
     if error:
@@ -2633,6 +2775,11 @@ async def anthropic_messages(
 
     body["model"] = upstream_model
 
+    # Parameters this model has already rejected are fixed up front, so the retry
+    # loop below costs one round trip per model rather than one per request (#83).
+    # The identity injection lands after this, and adds only a top-level system block.
+    reconciled: list[str] = _preapply_known_fixes(body, upstream_model)
+
     headers = _anthropic_auth_headers(raw, body)
 
     # OAuth subscription tokens (Bearer) gate Sonnet/Opus behind the Claude Code
@@ -2657,37 +2804,38 @@ async def anthropic_messages(
         start_time = time.time()
         clamped = False
         async with httpx.AsyncClient(timeout=300) as client:
-            try:
-                upstream = await client.post(_ANTHROPIC_UPSTREAM, headers=headers, json=body)
-            except httpx.HTTPError as e:
-                _record_messages_usage(
-                    log_entry, upstream_model, 0, 0, status="error",
-                    latency_ms=int((time.time() - start_time) * 1000),
-                    error=f"upstream_error: {e}",
-                )
-                raise HTTPException(status_code=502, detail=f"upstream error: {e}")
-
-            # Reconcile max_tokens against the routed model's output ceiling (#73):
-            # on a "max_tokens: N > M" 400, clamp to M and retry once.
-            if upstream.status_code == 400:
+            # Reconcile the request against the routed model and retry, bounded:
+            # max_tokens above the model's ceiling (#73), or a parameter the model
+            # does not support (#83). Both are knowable only from the 400.
+            for _attempt in range(_MAX_RECONCILE_ATTEMPTS):
+                try:
+                    upstream = await client.post(_ANTHROPIC_UPSTREAM, headers=headers, json=body)
+                except httpx.HTTPError as e:
+                    _record_messages_usage(
+                        log_entry, upstream_model, 0, 0, status="error",
+                        latency_ms=int((time.time() - start_time) * 1000),
+                        clamped=clamped, extra_modifiers=reconciled,
+                        error=f"upstream_error: {e}",
+                    )
+                    raise HTTPException(status_code=502, detail=f"upstream error: {e}")
+                if upstream.status_code != 400:
+                    break
+                fixes = []
                 ceiling = _parse_max_tokens_ceiling(upstream.text)
                 if ceiling is not None and (body.get("max_tokens") or 0) > ceiling:
                     body["max_tokens"] = ceiling
                     clamped = True
-                    try:
-                        upstream = await client.post(_ANTHROPIC_UPSTREAM, headers=headers, json=body)
-                    except httpx.HTTPError as e:
-                        _record_messages_usage(
-                            log_entry, upstream_model, 0, 0, status="error",
-                            latency_ms=int((time.time() - start_time) * 1000),
-                            clamped=True, error=f"upstream_error: {e}",
-                        )
-                        raise HTTPException(status_code=502, detail=f"upstream error: {e}")
+                    fixes.append(f"max_tokens_clamp({ceiling})")
+                fixes += _reconcile_from_error(body, upstream_model, upstream.text)
+                if not fixes:
+                    break  # nothing we know how to fix — surface the error
+                reconciled += fixes
 
         if upstream.status_code != 200:
             _record_messages_usage(
                 log_entry, upstream_model, 0, 0, status="error",
                 latency_ms=int((time.time() - start_time) * 1000), clamped=clamped,
+                extra_modifiers=reconciled,
                 error=f"upstream_status_{upstream.status_code}: {upstream.text[:500]}",
             )
             resp = Response(
@@ -2697,6 +2845,8 @@ async def anthropic_messages(
             )
             if clamped:
                 resp.headers["X-NadirClaw-MaxTokens-Clamped"] = "true"
+            if reconciled:
+                resp.headers["X-NadirClaw-Params-Reconciled"] = "true"
             return resp
 
         payload = upstream.json()
@@ -2705,20 +2855,25 @@ async def anthropic_messages(
             log_entry, upstream_model,
             usage.get("input_tokens", 0), usage.get("output_tokens", 0),
             status="ok", latency_ms=int((time.time() - start_time) * 1000),
-            clamped=clamped,
+            clamped=clamped, extra_modifiers=reconciled,
             response_preview=_extract_text_from_anthropic_response(payload)[:200],
         )
         resp = JSONResponse(content=payload, status_code=200)
         if clamped:
             resp.headers["X-NadirClaw-MaxTokens-Clamped"] = "true"
+        if reconciled:
+            resp.headers["X-NadirClaw-Params-Reconciled"] = "true"
         return resp
 
     # Streaming: pipe SSE bytes through, recovering usage from the event stream.
     async def proxy_stream():
         start_time = time.time()
         clamped = False
+        applied = list(reconciled)
         async with httpx.AsyncClient(timeout=300) as client:
-            for attempt in range(2):  # at most one max_tokens clamp-retry (#73)
+            # Same bounded reconcile loop as the non-streaming path. Retrying is safe
+            # because a non-200 status arrives before any SSE byte is forwarded.
+            for attempt in range(_MAX_RECONCILE_ATTEMPTS):
                 input_tokens = 0
                 output_tokens = 0
                 buffer = ""
@@ -2728,15 +2883,21 @@ async def anthropic_messages(
                     if upstream.status_code != 200:
                         err_body = await upstream.aread()
                         err_text = err_body.decode("utf-8", errors="replace")
-                        if attempt == 0 and upstream.status_code == 400:
+                        if attempt < _MAX_RECONCILE_ATTEMPTS - 1 and upstream.status_code == 400:
+                            fixes = []
                             ceiling = _parse_max_tokens_ceiling(err_text)
                             if ceiling is not None and (body.get("max_tokens") or 0) > ceiling:
                                 body["max_tokens"] = ceiling
                                 clamped = True
+                                fixes.append(f"max_tokens_clamp({ceiling})")
+                            fixes += _reconcile_from_error(body, upstream_model, err_text)
+                            if fixes:
+                                applied += fixes
                                 continue
                         _record_messages_usage(
                             log_entry, upstream_model, 0, 0, status="error",
                             latency_ms=int((time.time() - start_time) * 1000), clamped=clamped,
+                            extra_modifiers=applied,
                             error=f"upstream_stream_status_{upstream.status_code}: {err_text[:500]}",
                         )
                         yield f"event: error\ndata: {json.dumps({'type': 'error', 'error': {'type': 'upstream_error', 'message': err_text[:500]}})}\n\n".encode()
@@ -2763,7 +2924,7 @@ async def anthropic_messages(
                     _record_messages_usage(
                         log_entry, upstream_model, input_tokens, output_tokens,
                         status="ok", latency_ms=int((time.time() - start_time) * 1000),
-                        clamped=clamped,
+                        clamped=clamped, extra_modifiers=applied,
                     )
                     return
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 """Tests for nadirclaw.server — health endpoint and basic API contract."""
 
 import pytest
+from copy import deepcopy
 from unittest.mock import patch
 from fastapi.testclient import TestClient
 
@@ -696,6 +697,294 @@ class TestMaxTokensClamp:
         assert resp.status_code == 400
         assert len(calls) == 1  # no retry
         assert "X-NadirClaw-MaxTokens-Clamped" not in resp.headers
+
+
+class TestParamReconcile:
+    """#83 — reconcile request parameters the routed model does not support."""
+
+    @staticmethod
+    def _clear_cache():
+        from nadirclaw.server import _MODEL_PARAM_FIXES
+        _MODEL_PARAM_FIXES.clear()
+
+    # --- individual fixers ---------------------------------------------------
+
+    def test_rewrites_adaptive_to_enabled_below_max_tokens(self):
+        from nadirclaw.server import _downgrade_adaptive_thinking
+        body = {"max_tokens": 8192, "thinking": {"type": "adaptive", "display": "omitted"}}
+        modifier = _downgrade_adaptive_thinking(body)
+        assert body["thinking"] == {
+            "type": "enabled", "budget_tokens": 8191, "display": "omitted",
+        }
+        assert modifier == "thinking_downgrade(adaptive\u2192enabled, budget=8191)"
+
+    def test_thinking_budget_is_capped(self):
+        from nadirclaw.server import _downgrade_adaptive_thinking, _MAX_THINKING_BUDGET
+        body = {"max_tokens": 200000, "thinking": {"type": "adaptive"}}
+        _downgrade_adaptive_thinking(body)
+        assert body["thinking"]["budget_tokens"] == _MAX_THINKING_BUDGET
+        assert "display" not in body["thinking"]
+
+    def test_thinking_is_dropped_when_no_budget_fits(self):
+        """budget_tokens must be >= 1024 and < max_tokens, so tiny caps leave no room."""
+        from nadirclaw.server import _downgrade_adaptive_thinking
+        body = {"max_tokens": 512, "thinking": {"type": "adaptive"}}
+        assert _downgrade_adaptive_thinking(body) == "thinking_downgrade(adaptive\u2192off)"
+        assert "thinking" not in body
+
+    def test_other_thinking_shapes_are_untouched(self):
+        from nadirclaw.server import _downgrade_adaptive_thinking
+        for thinking in ({"type": "enabled", "budget_tokens": 2000}, {"type": "disabled"}):
+            body = {"max_tokens": 8192, "thinking": dict(thinking)}
+            assert _downgrade_adaptive_thinking(body) is None
+            assert body["thinking"] == thinking
+        assert _downgrade_adaptive_thinking({"max_tokens": 8192}) is None
+
+    def test_drops_effort_from_output_config(self):
+        from nadirclaw.server import _drop_effort
+        body = {"output_config": {"effort": "high"}}
+        assert _drop_effort(body) == "effort_drop(high)"
+        assert "output_config" not in body  # emptied, so removed entirely
+
+        body = {"output_config": {"effort": "high", "other": 1}}
+        assert _drop_effort(body) == "effort_drop(high)"
+        assert body["output_config"] == {"other": 1}
+
+        body = {"effort": "low"}
+        assert _drop_effort(body) == "effort_drop(low)"
+        assert body == {}
+
+        assert _drop_effort({"output_config": {"other": 1}}) is None
+
+    def test_folds_system_messages_into_the_system_field(self):
+        from nadirclaw.server import _fold_system_messages
+        body = {
+            "system": [{"type": "text", "text": "first"}],
+            "messages": [
+                {"role": "system", "content": "from a message"},
+                {"role": "user", "content": "hi"},
+            ],
+        }
+        assert _fold_system_messages(body) == "system_role_fold(1)"
+        assert body["system"] == [
+            {"type": "text", "text": "first"},
+            {"type": "text", "text": "from a message"},
+        ]
+        assert body["messages"] == [{"role": "user", "content": "hi"}]
+
+    def test_fold_leaves_a_body_with_no_other_message(self):
+        """Anthropic needs >= 1 message, so folding the only turn would be invalid."""
+        from nadirclaw.server import _fold_system_messages
+        body = {"messages": [{"role": "system", "content": "only"}]}
+        assert _fold_system_messages(body) is None
+        assert body["messages"] == [{"role": "system", "content": "only"}]
+
+    def test_fold_is_a_noop_without_system_turns(self):
+        from nadirclaw.server import _fold_system_messages
+        body = {"messages": [{"role": "user", "content": "hi"}]}
+        assert _fold_system_messages(body) is None
+
+    # --- error matching and caching ------------------------------------------
+
+    def test_each_400_selects_its_own_fixer(self):
+        from nadirclaw.server import _reconcile_from_error, _MODEL_PARAM_FIXES
+        self._clear_cache()
+        body = {"max_tokens": 8192, "thinking": {"type": "adaptive"}}
+        assert _reconcile_from_error(body, "m", "adaptive thinking is not supported on this model")
+        assert body["thinking"]["type"] == "enabled"
+
+        body = {"output_config": {"effort": "high"}}
+        assert _reconcile_from_error(body, "m", "This model does not support the effort parameter.")
+        assert "output_config" not in body
+
+        assert _MODEL_PARAM_FIXES["m"] == {"thinking", "effort"}
+        self._clear_cache()
+
+    def test_unknown_400_matches_nothing(self):
+        from nadirclaw.server import _reconcile_from_error, _MODEL_PARAM_FIXES
+        self._clear_cache()
+        body = {"max_tokens": 8192, "thinking": {"type": "adaptive"}}
+        assert _reconcile_from_error(body, "m", "some unrelated bad request") == []
+        assert _reconcile_from_error(body, "m", "") == []
+        assert body["thinking"] == {"type": "adaptive"}  # untouched
+        assert not _MODEL_PARAM_FIXES
+
+    def test_known_fixes_are_preapplied(self):
+        from nadirclaw.server import _preapply_known_fixes, _MODEL_PARAM_FIXES
+        self._clear_cache()
+        assert _preapply_known_fixes({"max_tokens": 8192}, "m") == []
+        _MODEL_PARAM_FIXES["m"] = {"thinking", "effort"}
+        body = {"max_tokens": 8192, "thinking": {"type": "adaptive"},
+                "output_config": {"effort": "high"}}
+        modifiers = _preapply_known_fixes(body, "m")
+        assert set(modifiers) == {
+            "thinking_downgrade(adaptive\u2192enabled, budget=8191)", "effort_drop(high)",
+        }
+        assert body["thinking"]["type"] == "enabled" and "output_config" not in body
+        self._clear_cache()
+
+    def test_modifiers_are_recorded_in_the_request_log(self):
+        from nadirclaw.server import _record_messages_usage
+        captured = {}
+        with patch("nadirclaw.server._log_request", side_effect=lambda e: captured.update(e)):
+            _record_messages_usage(
+                {"type": "messages", "modifiers_applied": ["agent_role[SUBAGENT]"]},
+                "claude-haiku-4-5", 10, 5,
+                extra_modifiers=["thinking_downgrade(adaptive\u2192enabled, budget=8191)"],
+            )
+        assert captured["modifiers_applied"] == [
+            "agent_role[SUBAGENT]",
+            "thinking_downgrade(adaptive\u2192enabled, budget=8191)",
+        ]
+
+    # --- end to end through the endpoint ------------------------------------
+
+    @staticmethod
+    def _fake_client(error_messages):
+        """Fake httpx client that 400s with each message in turn, then succeeds."""
+        import httpx
+        sent = []
+        remaining = list(error_messages)
+
+        class _Resp:
+            def __init__(self, message=None):
+                self._message = message
+                self.status_code = 400 if message else 200
+                self.text = ('{"type":"error","error":{"type":"invalid_request_error",'
+                             f'"message":"{message}"}}}}') if message else "{}"
+                self.content = self.text.encode()
+                self.headers = {"content-type": "application/json"}
+            def json(self):
+                return {"id": "msg_1", "content": [{"type": "text", "text": "ok"}],
+                        "usage": {"input_tokens": 3, "output_tokens": 2}}
+
+        class _FakeClient:
+            def __init__(self, *a, **kw): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): return False
+            async def post(self, url, headers=None, json=None):
+                # deep copy: the fixers mutate these structures in place
+                sent.append(deepcopy(
+                    {k: json.get(k) for k in ("thinking", "output_config", "messages")}
+                ))
+                return _Resp(remaining.pop(0) if remaining else None)
+
+        return httpx, _FakeClient, sent
+
+    def test_converges_over_successive_400s(self, client):
+        """One request absorbs every unsupported-parameter 400 and still returns 200."""
+        self._clear_cache()
+        httpx, _FakeClient, sent = self._fake_client([
+            "adaptive thinking is not supported on this model",
+            "This model does not support the effort parameter.",
+        ])
+        try:
+            with patch("nadirclaw.credentials.get_credential", return_value="sk-ant-oat01-test"), \
+                 patch.object(httpx, "AsyncClient", _FakeClient):
+                resp = client.post("/v1/messages", json={
+                    "model": "nadir-eco", "max_tokens": 8192,
+                    "thinking": {"type": "adaptive"},
+                    "output_config": {"effort": "high"},
+                    "messages": [{"role": "user", "content": "hi"}],
+                })
+        finally:
+            self._clear_cache()
+
+        assert resp.status_code == 200
+        assert len(sent) == 3
+        assert sent[0]["thinking"] == {"type": "adaptive"}
+        assert sent[1]["thinking"] == {"type": "enabled", "budget_tokens": 8191}
+        assert sent[1]["output_config"] == {"effort": "high"}
+        assert sent[2]["output_config"] is None  # effort dropped on the last attempt
+        assert resp.headers.get("X-NadirClaw-Params-Reconciled") == "true"
+
+    def test_second_request_needs_no_failed_attempt(self, client):
+        """The cache makes the fixes pre-emptive, so the retry cost is once per model."""
+        from nadirclaw.server import _MODEL_PARAM_FIXES
+        from nadirclaw.settings import settings
+        self._clear_cache()
+        _MODEL_PARAM_FIXES[settings.SIMPLE_MODEL] = {"thinking", "effort"}
+        httpx, _FakeClient, sent = self._fake_client([])
+        try:
+            with patch("nadirclaw.credentials.get_credential", return_value="sk-ant-oat01-test"), \
+                 patch.object(httpx, "AsyncClient", _FakeClient):
+                resp = client.post("/v1/messages", json={
+                    "model": "nadir-eco", "max_tokens": 8192,
+                    "thinking": {"type": "adaptive"},
+                    "output_config": {"effort": "high"},
+                    "messages": [{"role": "user", "content": "hi"}],
+                })
+        finally:
+            self._clear_cache()
+
+        assert resp.status_code == 200
+        assert len(sent) == 1  # no wasted round trip
+        assert sent[0]["thinking"] == {"type": "enabled", "budget_tokens": 8191}
+        assert sent[0]["output_config"] is None
+
+    def test_unknown_400_is_returned_without_retrying(self, client):
+        from nadirclaw.server import _MODEL_PARAM_FIXES
+        self._clear_cache()
+        httpx, _FakeClient, sent = self._fake_client(["some unrelated bad request"])
+        with patch("nadirclaw.credentials.get_credential", return_value="sk-ant-oat01-test"), \
+             patch.object(httpx, "AsyncClient", _FakeClient):
+            resp = client.post("/v1/messages", json={
+                "model": "nadir-eco", "max_tokens": 8192,
+                "thinking": {"type": "adaptive"},
+                "messages": [{"role": "user", "content": "hi"}],
+            })
+        assert resp.status_code == 400
+        assert len(sent) == 1
+        assert sent[0]["thinking"] == {"type": "adaptive"}
+        assert "X-NadirClaw-Params-Reconciled" not in resp.headers
+        assert not _MODEL_PARAM_FIXES
+
+    def test_streaming_reconciles_before_any_byte_is_sent(self, client):
+        import httpx
+        self._clear_cache()
+        sent = []
+        remaining = ["adaptive thinking is not supported on this model"]
+
+        class _Stream:
+            def __init__(self, message=None):
+                self._message = message
+                self.status_code = 400 if message else 200
+            async def aread(self):
+                return (f'{{"type":"error","error":{{"message":"{self._message}"}}}}'.encode()
+                        if self._message else b"")
+            async def aiter_bytes(self):
+                yield (b'event: message_start\ndata: {"type":"message_start","message":'
+                       b'{"usage":{"input_tokens":3,"output_tokens":1}}}\n\n')
+
+        class _Ctx:
+            def __init__(self, resp): self._resp = resp
+            async def __aenter__(self): return self._resp
+            async def __aexit__(self, *a): return False
+
+        class _FakeClient:
+            def __init__(self, *a, **kw): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): return False
+            def stream(self, method, url, headers=None, json=None):
+                sent.append(json.get("thinking"))
+                return _Ctx(_Stream(remaining.pop(0) if remaining else None))
+
+        try:
+            with patch("nadirclaw.credentials.get_credential", return_value="sk-ant-oat01-test"), \
+                 patch.object(httpx, "AsyncClient", _FakeClient):
+                resp = client.post("/v1/messages", json={
+                    "model": "nadir-eco", "max_tokens": 8192, "stream": True,
+                    "thinking": {"type": "adaptive"},
+                    "messages": [{"role": "user", "content": "hi"}],
+                })
+                text = resp.text
+        finally:
+            self._clear_cache()
+
+        assert resp.status_code == 200
+        assert sent == [{"type": "adaptive"}, {"type": "enabled", "budget_tokens": 8191}]
+        assert "message_start" in text
+        assert "upstream_error" not in text  # the 400 never reached the client
 
 
 class TestCountTokensEndpoint:


### PR DESCRIPTION
Fixes #83.

## Problem

Clients pick request parameters from the model id **they** can see. Behind this proxy that id is a router alias (`nadir-auto`, `nadir-eco`), which no capability table knows, so the client assumes the newest model capabilities. Routing then selects the real model **after** that decision. When routing picks an older, cheaper model, the request carries parameters that model rejects, and every request 400s.

The cheap tier is therefore unusable under Claude Code: the moment the classifier says `simple`, the request fails. That defeats the point of the router.

I originally reported this as "the client always sends adaptive thinking". That was wrong, and I corrected it [in the issue](https://github.com/NadirRouter/NadirClaw/issues/83#issuecomment-5252363588): the client does check the model, it just cannot check a model it has not been told about. This is why the fix belongs here — the proxy is the only component that knows both the requested parameters and the model that will serve them.

Measured before this change, `claude -p --model nadir-eco` with `NADIRCLAW_SIMPLE_MODEL=claude-haiku-4-5-20251001`, against a live Anthropic subscription:

```
nadir-eco -> claude-haiku-4-5-20251001  error  "adaptive thinking is not supported on this model"
nadir-eco -> claude-haiku-4-5-20251001  error  "This model does not support the effort parameter."
nadir-eco -> claude-haiku-4-5-20251001  error  "role 'system' is not supported on this model"
nadir-eco -> claude-haiku-4-5-20251001  ok
```

Three failed upstream calls per request, repeated identically on every request. The user still got an answer only because Claude Code degrades its own request shape and retries.

## What this does

`/v1/messages` reconciles the request against the 400 it gets back and retries **within the same request**, bounded to 4 attempts:

| Anthropic 400 | Fix | Modifier recorded |
|---|---|---|
| `adaptive thinking is not supported` | `thinking: {"type":"adaptive"}` → `{"type":"enabled","budget_tokens":N}`, clamped to `1024 <= N < max_tokens` and capped at 32000 | `thinking_downgrade(adaptive→enabled, budget=N)` |
| `does not support the effort parameter` | drop `output_config.effort` (or top-level `effort`) | `effort_drop(high)` |
| `role 'system' is not supported` | fold `system`/`developer` turns into the top-level `system` field | `system_role_fold(N)` |

Each fix is remembered per model in a process-local cache and pre-applied on later requests, so discovery costs one round trip per model per process, not one per request. An unrecognised 400 is returned untouched and never retried.

Applied fixes land in `requests.jsonl` as `modifiers_applied` entries, alongside the existing `context_window_swap` and `agent_role` modifiers, and in an `X-NadirClaw-Params-Reconciled` response header. The existing `max_tokens` clamp (#73) now runs inside the same loop and keeps its own header.

## Why this shape

- **It mirrors a pattern already in the codebase.** The `max_tokens` clamp-retry for #73 does exactly this: read the ceiling out of the 400, fix the body, retry once. This generalises that loop rather than adding a second mechanism.
- **No capability list to maintain.** Hardcoding which models support which parameter would need syncing on every model release, and it fails in the wrong direction: an unknown new model would be assumed capable and 400. Learning from the error stays correct as the API changes.
- **`thinking` intent is preserved, not discarded.** Older models accept `enabled` with a budget, so the request still thinks. Only `effort`, which merely shapes how hard the model tries, is dropped.
- **The system fold already exists here.** 0.21.1 applied the same fix to the OAuth completion path for #74. This brings the passthrough in line.
- **Bounded.** 4 attempts covers the three known fixes plus the clamp; a misbehaving upstream cannot loop.

## Evidence after

Same command, same config, after the change:

```
nadir-eco -> claude-haiku-4-5-20251001  ok  in=1077 out=43  cost=$0.001292
  modifiers_applied=[thinking_downgrade(adaptive→enabled, budget=31999),
                     effort_drop(high), system_role_fold(1)]
```

One upstream call, no errors. Two further requests produced one call each and **zero** new reconcile warnings in the server log, which confirms the cache: the three `rejected a parameter` warnings appear exactly once per model per process.

## Tests

16 new tests in `tests/test_server.py::TestParamReconcile` cover each fixer in isolation (including the budget clamp, the no-room-for-a-budget case, and the fold that would leave zero messages), the error matching, the per-model cache, the log modifier, and four end-to-end cases through the endpoint: convergence over successive 400s, a second request with no wasted call, an unknown 400 passed through unretried, and the streaming path retrying before any SSE byte is forwarded.

`pytest` on a clean checkout: **886 passed, 1 skipped**.

One note in case you see it: with a populated `~/.nadirclaw/.env` I get 10 pre-existing failures in `test_routing.py`/`test_server.py`, because those tests assert on default model names and the settings module reads the user's real `.env`. They fail identically on `main` without this branch, and all pass with a pristine `HOME`. Unrelated to this change, but it might be worth isolating settings in those tests.

## Not included

The OpenAI-compatible `/v1/chat/completions` path forwards `thinking` at three sites and can hit the same 400 for OpenClaw and Codex users. The helpers here are path-agnostic, so wiring them in there is small, but I kept this PR to the path where the bug reproduces. Happy to extend it in this PR if you prefer.
